### PR TITLE
feat: add SkillExecutor trait, session management, and skill-files parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,11 +1817,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1832,7 +1853,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2731,7 +2752,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "http 1.4.0",
  "indicatif",
  "libc",
@@ -5529,6 +5550,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -7066,10 +7098,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thulp-skill-files"
+version = "0.1.0"
+dependencies = [
+ "dirs 5.0.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
 name = "thulp-skills"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "fastrand",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7079,6 +7127,7 @@ dependencies = [
  "thulp-mcp",
  "thulp-query",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7092,6 +7141,8 @@ dependencies = [
  "thiserror 2.0.17",
  "thulp-core",
  "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/thulp-registry",
     "crates/thulp-mcp",
     "crates/thulp-skills",
+    "crates/thulp-skill-files",
     "crates/thulp-cli",
     "examples",
 ]
@@ -32,6 +33,7 @@ thulp-mcp = { path = "crates/thulp-mcp" }
 thulp-adapter = { path = "crates/thulp-adapter" }
 thulp-workspace = { path = "crates/thulp-workspace" }
 thulp-skills = { path = "crates/thulp-skills" }
+thulp-skill-files = { path = "crates/thulp-skill-files" }
 thulp-browser = { path = "crates/thulp-browser" }
 thulp-guidance = { path = "crates/thulp-guidance" }
 thulp-registry = { path = "crates/thulp-registry" }

--- a/crates/thulp-skill-files/Cargo.toml
+++ b/crates/thulp-skill-files/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "thulp-skill-files"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SKILL.md file parsing and loading for Thulp"
+rust-version.workspace = true
+
+[dependencies]
+# Internal crates - thulp-skill-files is standalone, no internal deps needed
+# thulp-core = { workspace = true }
+# thulp-skills = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true, features = ["process", "fs"] }
+
+# Regex for preprocessor
+regex = "1.10"
+
+# Directory walking
+walkdir = "2.5"
+
+# Home directory detection
+dirs = "5.0"
+
+[dev-dependencies]
+tempfile = "3.14"

--- a/crates/thulp-skill-files/README.md
+++ b/crates/thulp-skill-files/README.md
@@ -1,0 +1,130 @@
+# thulp-skill-files
+
+SKILL.md file parsing and loading for the Thulp execution context platform.
+
+## Features
+
+- **SKILL.md Parsing**: Parse skill files with YAML frontmatter and markdown content
+- **Preprocessor**: Handle `$ARGUMENTS`, `!`command``, `{{variable}}`, and `${ENV_VAR}` substitutions
+- **Skill Loader**: Discover skills from multiple directories with scope-based priority
+- **Tool Restrictions**: Support for `allowed-tools` to sandbox skill execution
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+thulp-skill-files = { path = "../thulp-skill-files" }
+```
+
+## Quick Start
+
+### Parsing a Skill File
+
+```rust
+use thulp_skill_files::SkillFile;
+
+let skill = SkillFile::parse("path/to/SKILL.md")?;
+println!("Name: {}", skill.effective_name());
+println!("Description: {}", skill.effective_description());
+```
+
+### Loading Skills from Directories
+
+```rust
+use thulp_skill_files::{SkillLoader, SkillLoaderConfig};
+
+let config = SkillLoaderConfig::default();
+let loader = SkillLoader::new(config);
+let skills = loader.load_all()?;
+
+for skill in &skills {
+    println!("{} ({})", skill.qualified_name(), skill.scope);
+}
+```
+
+### Preprocessing Skill Content
+
+```rust
+use thulp_skill_files::SkillPreprocessor;
+use std::collections::HashMap;
+
+let pp = SkillPreprocessor::new();
+let mut context = HashMap::new();
+context.insert("project".to_string(), serde_json::json!("myapp"));
+
+let content = "Process $ARGUMENTS for {{project}}";
+let processed = pp.preprocess(content, "file.txt", &context)?;
+// Result: "Process file.txt for myapp"
+```
+
+## SKILL.md Format
+
+```markdown
+---
+name: my-skill
+description: Does something useful
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+disable-model-invocation: false
+user-invocable: true
+context: inline
+requires-approval: false
+tags:
+  - utility
+  - files
+---
+# Instructions
+
+When invoked with $ARGUMENTS, do the following:
+
+1. Read the specified file
+2. Process the contents
+3. Write the results
+```
+
+## Frontmatter Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | directory name | Display name |
+| `description` | string | first paragraph | What the skill does |
+| `argument-hint` | string | - | Hint for arguments |
+| `disable-model-invocation` | bool | false | Prevent automatic invocation |
+| `user-invocable` | bool | true | Allow user invocation |
+| `allowed-tools` | list | all | Restrict tool usage |
+| `model` | string | - | Model to use |
+| `context` | inline/fork | inline | Execution context |
+| `agent` | string | - | Subagent type for fork |
+| `requires-approval` | bool | false | Require user approval |
+| `tags` | list | [] | Categorization tags |
+| `version` | string | - | Skill version |
+| `author` | string | - | Skill author |
+
+## Scope Priority
+
+Skills are loaded from multiple directories with priority resolution:
+
+1. **Enterprise** (highest) - Organization-wide skills
+2. **Personal** - User's personal skills (~/.claude/skills/)
+3. **Project** (lowest) - Project-specific skills (./.claude/skills/)
+4. **Plugin** - Namespaced, no conflicts
+
+When multiple skills have the same name, higher scope wins.
+
+## Preprocessor Substitutions
+
+| Syntax | Description |
+|--------|-------------|
+| `$ARGUMENTS` | Replaced with invocation arguments |
+| `!`command`` | Replaced with shell command output |
+| `{{variable}}` | Replaced with context value |
+| `{{a.b.c}}` | Replaced with nested context value |
+| `${ENV_VAR}` | Replaced with environment variable |
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/thulp-skill-files/src/error.rs
+++ b/crates/thulp-skill-files/src/error.rs
@@ -1,0 +1,50 @@
+//! Error types for skill file operations.
+
+use thiserror::Error;
+
+/// Result type alias for skill file operations.
+pub type Result<T> = std::result::Result<T, SkillFileError>;
+
+/// Errors that can occur when working with skill files.
+#[derive(Debug, Error)]
+pub enum SkillFileError {
+    /// IO error when reading/writing files.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// YAML parsing error in frontmatter.
+    #[error("YAML parsing error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    /// General parsing error.
+    #[error("Parse error: {0}")]
+    Parse(String),
+
+    /// Invalid path provided.
+    #[error("Invalid path: {0}")]
+    InvalidPath(String),
+
+    /// Shell command execution error.
+    #[error("Command execution error: {0}")]
+    CommandExecution(String),
+
+    /// Variable not found during substitution.
+    #[error("Variable not found: {0}")]
+    VariableNotFound(String),
+
+    /// Skill not found in registry.
+    #[error("Skill not found: {0}")]
+    SkillNotFound(String),
+
+    /// Tool not allowed for skill execution.
+    #[error("Tool not allowed: {0}")]
+    ToolNotAllowed(String),
+
+    /// Skill requires user approval before execution.
+    #[error("Approval required for skill: {0}")]
+    ApprovalRequired(String),
+
+    /// Regex compilation error.
+    #[error("Regex error: {0}")]
+    Regex(#[from] regex::Error),
+}

--- a/crates/thulp-skill-files/src/frontmatter.rs
+++ b/crates/thulp-skill-files/src/frontmatter.rs
@@ -1,0 +1,236 @@
+//! YAML frontmatter types for SKILL.md files.
+//!
+//! This module defines the structure of the YAML frontmatter that appears
+//! at the top of SKILL.md files, between `---` delimiters.
+
+use serde::{Deserialize, Serialize};
+
+/// YAML frontmatter configuration for a skill file.
+///
+/// All fields are optional - skills can be defined with just content
+/// and no frontmatter at all.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct SkillFrontmatter {
+    /// Display name for the skill (defaults to directory name).
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// What the skill does and when to use it.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// Hint shown during autocomplete for expected arguments.
+    #[serde(default)]
+    pub argument_hint: Option<String>,
+
+    /// Prevent agent from automatically invoking this skill.
+    #[serde(default)]
+    pub disable_model_invocation: bool,
+
+    /// Whether users can invoke this skill directly (default: true).
+    #[serde(default = "default_true")]
+    pub user_invocable: bool,
+
+    /// Tools the skill is allowed to use.
+    /// If None, all tools are allowed.
+    #[serde(default)]
+    pub allowed_tools: Option<Vec<String>>,
+
+    /// Model to use when this skill is active.
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// Execution context: "fork" for subagent, "inline" for current context.
+    #[serde(default)]
+    pub context: Option<SkillContext>,
+
+    /// Which subagent type to use when context is "fork".
+    #[serde(default)]
+    pub agent: Option<String>,
+
+    /// Hooks scoped to this skill's lifecycle.
+    #[serde(default)]
+    pub hooks: Option<SkillHooks>,
+
+    // === DOT DOT Marketplace Extensions ===
+    /// Skill version (semver).
+    #[serde(default)]
+    pub version: Option<String>,
+
+    /// Author identifier.
+    #[serde(default)]
+    pub author: Option<String>,
+
+    /// Pricing model for marketplace.
+    #[serde(default)]
+    pub price: Option<PriceModel>,
+
+    /// Whether this skill requires user approval before execution.
+    #[serde(default)]
+    pub requires_approval: bool,
+
+    /// Tags for categorization.
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    /// Minimum Thulp version required.
+    #[serde(default)]
+    pub min_thulp_version: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for SkillFrontmatter {
+    fn default() -> Self {
+        Self {
+            name: None,
+            description: None,
+            argument_hint: None,
+            disable_model_invocation: false,
+            user_invocable: true, // Default to true
+            allowed_tools: None,
+            model: None,
+            context: None,
+            agent: None,
+            hooks: None,
+            version: None,
+            author: None,
+            price: None,
+            requires_approval: false,
+            tags: Vec::new(),
+            min_thulp_version: None,
+        }
+    }
+}
+
+/// Execution context for skills.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillContext {
+    /// Run in current conversation context.
+    #[default]
+    Inline,
+    /// Run in isolated subagent context.
+    Fork,
+}
+
+/// Pricing model for marketplace skills.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum PriceModel {
+    /// Free skill (represented as "free" string).
+    Free,
+    /// Fixed price per call.
+    PerCall(f64),
+    /// Subscription-based pricing.
+    Subscription {
+        /// Monthly subscription cost.
+        monthly: f64,
+    },
+    /// Custom pricing string.
+    Custom(String),
+}
+
+// Note: Can't use #[derive(Default)] with #[serde(untagged)] - serde parsing breaks
+#[allow(clippy::derivable_impls)]
+impl Default for PriceModel {
+    fn default() -> Self {
+        Self::Free
+    }
+}
+
+/// Lifecycle hooks for skills.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct SkillHooks {
+    /// Run before skill starts.
+    #[serde(default)]
+    pub pre_execute: Option<String>,
+
+    /// Run after skill completes.
+    #[serde(default)]
+    pub post_execute: Option<String>,
+
+    /// Run on error.
+    #[serde(default)]
+    pub on_error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_frontmatter() {
+        let fm = SkillFrontmatter::default();
+        assert!(fm.name.is_none());
+        assert!(fm.user_invocable); // Should default to true
+        assert!(!fm.disable_model_invocation);
+        assert!(!fm.requires_approval);
+    }
+
+    #[test]
+    fn test_parse_minimal_frontmatter() {
+        let yaml = r#"
+name: test-skill
+description: A test skill
+"#;
+        let fm: SkillFrontmatter = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(fm.name, Some("test-skill".to_string()));
+        assert_eq!(fm.description, Some("A test skill".to_string()));
+    }
+
+    #[test]
+    fn test_parse_full_frontmatter() {
+        let yaml = r#"
+name: advanced-skill
+description: An advanced skill with all options
+argument-hint: <file-path>
+disable-model-invocation: true
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+model: claude-sonnet-4-20250514
+context: fork
+agent: code-reviewer
+requires-approval: true
+tags:
+  - code
+  - review
+version: 1.2.3
+author: dirmacs
+"#;
+        let fm: SkillFrontmatter = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(fm.name, Some("advanced-skill".to_string()));
+        assert!(fm.disable_model_invocation);
+        assert!(!fm.user_invocable);
+        assert_eq!(
+            fm.allowed_tools,
+            Some(vec![
+                "Read".to_string(),
+                "Write".to_string(),
+                "Bash".to_string()
+            ])
+        );
+        assert_eq!(fm.context, Some(SkillContext::Fork));
+        assert_eq!(fm.agent, Some("code-reviewer".to_string()));
+        assert!(fm.requires_approval);
+        assert_eq!(fm.tags, vec!["code".to_string(), "review".to_string()]);
+    }
+
+    #[test]
+    fn test_skill_context_serialization() {
+        assert_eq!(
+            serde_yaml::to_string(&SkillContext::Fork).unwrap().trim(),
+            "fork"
+        );
+        assert_eq!(
+            serde_yaml::to_string(&SkillContext::Inline).unwrap().trim(),
+            "inline"
+        );
+    }
+}

--- a/crates/thulp-skill-files/src/lib.rs
+++ b/crates/thulp-skill-files/src/lib.rs
@@ -1,0 +1,77 @@
+//! # thulp-skill-files
+//!
+//! SKILL.md file parsing and loading for the Thulp execution context platform.
+//!
+//! This crate provides functionality for:
+//! - Parsing SKILL.md files with YAML frontmatter
+//! - Preprocessing skill content (arguments, commands, variables)
+//! - Loading skills from directories with scope-based priority
+//!
+//! ## Quick Start
+//!
+//! ```rust,ignore
+//! use thulp_skill_files::{SkillFile, SkillLoader, SkillLoaderConfig, SkillPreprocessor};
+//! use std::collections::HashMap;
+//!
+//! // Parse a single skill file
+//! let skill = SkillFile::parse("path/to/SKILL.md")?;
+//! println!("Skill: {}", skill.effective_name());
+//!
+//! // Load all skills from configured directories
+//! let config = SkillLoaderConfig::default();
+//! let loader = SkillLoader::new(config);
+//! let skills = loader.load_all()?;
+//!
+//! // Preprocess skill content
+//! let pp = SkillPreprocessor::new();
+//! let context = HashMap::new();
+//! let processed = pp.preprocess(&skill.content, "my args", &context)?;
+//! ```
+//!
+//! ## SKILL.md Format
+//!
+//! Skills are defined in SKILL.md files with optional YAML frontmatter:
+//!
+//! ```markdown
+//! ---
+//! name: my-skill
+//! description: Does something useful
+//! allowed-tools:
+//!   - Read
+//!   - Write
+//! ---
+//! # Instructions
+//!
+//! When invoked with $ARGUMENTS, do the following...
+//! ```
+//!
+//! ## Frontmatter Options
+//!
+//! | Field | Type | Description |
+//! |-------|------|-------------|
+//! | `name` | string | Display name (defaults to directory name) |
+//! | `description` | string | What the skill does |
+//! | `argument-hint` | string | Hint for expected arguments |
+//! | `disable-model-invocation` | bool | Prevent automatic invocation |
+//! | `user-invocable` | bool | Allow user to invoke (default: true) |
+//! | `allowed-tools` | list | Restrict tools the skill can use |
+//! | `context` | inline/fork | Execution context |
+//! | `requires-approval` | bool | Require user approval |
+//!
+//! ## Scope Priority
+//!
+//! Skills are loaded with priority: Enterprise > Personal > Project.
+//! Plugin skills are namespaced and don't conflict.
+
+pub mod error;
+pub mod frontmatter;
+pub mod loader;
+pub mod parser;
+pub mod preprocessor;
+
+// Re-export main types
+pub use error::{Result, SkillFileError};
+pub use frontmatter::{PriceModel, SkillContext, SkillFrontmatter, SkillHooks};
+pub use loader::{LoadedSkill, SkillLoader, SkillLoaderConfig, SkillScope};
+pub use parser::{SkillFile, SupportingFile, SupportingFileType};
+pub use preprocessor::SkillPreprocessor;

--- a/crates/thulp-skill-files/src/loader.rs
+++ b/crates/thulp-skill-files/src/loader.rs
@@ -1,0 +1,315 @@
+//! Skill loader and directory scanner.
+//!
+//! Discovers and loads skills from configured directories with
+//! scope-based priority resolution.
+
+use crate::error::Result;
+use crate::parser::SkillFile;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Scope levels for skill priority.
+///
+/// Higher scope values take precedence over lower ones when
+/// multiple skills have the same name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SkillScope {
+    /// Lowest priority: project-level skills.
+    Project = 0,
+    /// Medium priority: user's personal skills.
+    Personal = 1,
+    /// Highest priority: enterprise/organization skills.
+    Enterprise = 2,
+    /// Plugin skills (namespaced, don't conflict).
+    Plugin = 3,
+}
+
+impl std::fmt::Display for SkillScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SkillScope::Project => write!(f, "project"),
+            SkillScope::Personal => write!(f, "personal"),
+            SkillScope::Enterprise => write!(f, "enterprise"),
+            SkillScope::Plugin => write!(f, "plugin"),
+        }
+    }
+}
+
+/// Configuration for skill loading.
+#[derive(Debug, Clone)]
+pub struct SkillLoaderConfig {
+    /// Project skills directory (e.g., ./.claude/skills/).
+    pub project_dir: Option<PathBuf>,
+    /// Personal skills directory (e.g., ~/.claude/skills/).
+    pub personal_dir: Option<PathBuf>,
+    /// Enterprise skills directory.
+    pub enterprise_dir: Option<PathBuf>,
+    /// Plugin directories.
+    pub plugin_dirs: Vec<PathBuf>,
+    /// Maximum directory depth to scan.
+    pub max_depth: usize,
+}
+
+impl Default for SkillLoaderConfig {
+    fn default() -> Self {
+        Self {
+            project_dir: Some(PathBuf::from(".claude/skills")),
+            personal_dir: dirs::home_dir().map(|h| h.join(".claude/skills")),
+            enterprise_dir: None,
+            plugin_dirs: Vec::new(),
+            max_depth: 3,
+        }
+    }
+}
+
+impl SkillLoaderConfig {
+    /// Create a config with only project directory.
+    pub fn project_only(path: impl Into<PathBuf>) -> Self {
+        Self {
+            project_dir: Some(path.into()),
+            personal_dir: None,
+            enterprise_dir: None,
+            plugin_dirs: Vec::new(),
+            max_depth: 3,
+        }
+    }
+
+    /// Create a config for testing with a single directory.
+    pub fn single(path: impl Into<PathBuf>) -> Self {
+        Self::project_only(path)
+    }
+}
+
+/// Loaded skill with scope information.
+#[derive(Debug, Clone)]
+pub struct LoadedSkill {
+    /// The parsed skill file.
+    pub file: SkillFile,
+    /// Scope level of the skill.
+    pub scope: SkillScope,
+    /// For plugins, the plugin name prefix.
+    pub namespace: Option<String>,
+}
+
+impl LoadedSkill {
+    /// Get the fully qualified name (with namespace if applicable).
+    pub fn qualified_name(&self) -> String {
+        match &self.namespace {
+            Some(ns) => format!("{}:{}", ns, self.file.effective_name()),
+            None => self.file.effective_name(),
+        }
+    }
+
+    /// Get the effective description.
+    pub fn effective_description(&self) -> String {
+        self.file.effective_description()
+    }
+
+    /// Check if this skill can be invoked by the model.
+    pub fn is_model_invocable(&self) -> bool {
+        !self.file.frontmatter.disable_model_invocation
+    }
+
+    /// Check if this skill can be invoked by the user.
+    pub fn is_user_invocable(&self) -> bool {
+        self.file.frontmatter.user_invocable
+    }
+}
+
+/// Skill loader that discovers and loads skills from configured directories.
+pub struct SkillLoader {
+    config: SkillLoaderConfig,
+}
+
+impl SkillLoader {
+    /// Create a new skill loader with the given configuration.
+    pub fn new(config: SkillLoaderConfig) -> Self {
+        Self { config }
+    }
+
+    /// Create a skill loader with default configuration.
+    pub fn with_defaults() -> Self {
+        Self::new(SkillLoaderConfig::default())
+    }
+
+    /// Load all skills from configured directories.
+    pub fn load_all(&self) -> Result<Vec<LoadedSkill>> {
+        let mut skills = Vec::new();
+
+        // Load in priority order (lowest first, so higher priority overwrites)
+        if let Some(ref dir) = self.config.project_dir {
+            skills.extend(self.load_from_directory(dir, SkillScope::Project, None)?);
+        }
+
+        if let Some(ref dir) = self.config.personal_dir {
+            skills.extend(self.load_from_directory(dir, SkillScope::Personal, None)?);
+        }
+
+        if let Some(ref dir) = self.config.enterprise_dir {
+            skills.extend(self.load_from_directory(dir, SkillScope::Enterprise, None)?);
+        }
+
+        // Load plugins with namespace
+        for plugin_dir in &self.config.plugin_dirs {
+            if let Some(plugin_name) = plugin_dir.file_name().and_then(|n| n.to_str()) {
+                let skills_dir = plugin_dir.join("skills");
+                if skills_dir.exists() {
+                    skills.extend(self.load_from_directory(
+                        &skills_dir,
+                        SkillScope::Plugin,
+                        Some(plugin_name.to_string()),
+                    )?);
+                }
+            }
+        }
+
+        Ok(skills)
+    }
+
+    /// Load skills from a single directory.
+    fn load_from_directory(
+        &self,
+        dir: &Path,
+        scope: SkillScope,
+        namespace: Option<String>,
+    ) -> Result<Vec<LoadedSkill>> {
+        let mut skills = Vec::new();
+
+        if !dir.exists() {
+            return Ok(skills);
+        }
+
+        for entry in WalkDir::new(dir)
+            .max_depth(self.config.max_depth)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if path.is_file() && path.file_name() == Some(std::ffi::OsStr::new("SKILL.md")) {
+                match SkillFile::parse(path) {
+                    Ok(file) => {
+                        skills.push(LoadedSkill {
+                            file,
+                            scope,
+                            namespace: namespace.clone(),
+                        });
+                    }
+                    Err(e) => {
+                        // Log warning but continue loading other skills
+                        eprintln!("Warning: Failed to load skill at {:?}: {}", path, e);
+                    }
+                }
+            }
+        }
+
+        Ok(skills)
+    }
+
+    /// Resolve skills by priority (higher scope wins for same name).
+    pub fn resolve_priority(skills: Vec<LoadedSkill>) -> HashMap<String, LoadedSkill> {
+        let mut resolved: HashMap<String, LoadedSkill> = HashMap::new();
+
+        // Sort by scope (lowest first)
+        let mut sorted = skills;
+        sorted.sort_by_key(|s| s.scope);
+
+        for skill in sorted {
+            let name = skill.qualified_name();
+            // Higher scope always wins
+            if let Some(existing) = resolved.get(&name) {
+                if skill.scope >= existing.scope {
+                    resolved.insert(name, skill);
+                }
+            } else {
+                resolved.insert(name, skill);
+            }
+        }
+
+        resolved
+    }
+
+    /// Find a skill by name.
+    pub fn find_skill<'a>(skills: &'a [LoadedSkill], name: &str) -> Option<&'a LoadedSkill> {
+        skills
+            .iter()
+            .find(|s| s.file.effective_name() == name || s.qualified_name() == name)
+    }
+
+    /// Filter skills that are invocable by the model.
+    pub fn model_invocable(skills: &[LoadedSkill]) -> Vec<&LoadedSkill> {
+        skills.iter().filter(|s| s.is_model_invocable()).collect()
+    }
+
+    /// Filter skills that are invocable by the user.
+    pub fn user_invocable(skills: &[LoadedSkill]) -> Vec<&LoadedSkill> {
+        skills.iter().filter(|s| s.is_user_invocable()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skill_scope_ordering() {
+        assert!(SkillScope::Enterprise > SkillScope::Personal);
+        assert!(SkillScope::Personal > SkillScope::Project);
+        assert!(SkillScope::Plugin > SkillScope::Enterprise);
+    }
+
+    #[test]
+    fn test_qualified_name_no_namespace() {
+        let skill = LoadedSkill {
+            file: create_mock_skill_file("test-skill"),
+            scope: SkillScope::Project,
+            namespace: None,
+        };
+        assert_eq!(skill.qualified_name(), "test-skill");
+    }
+
+    #[test]
+    fn test_qualified_name_with_namespace() {
+        let skill = LoadedSkill {
+            file: create_mock_skill_file("helper"),
+            scope: SkillScope::Plugin,
+            namespace: Some("myplugin".to_string()),
+        };
+        assert_eq!(skill.qualified_name(), "myplugin:helper");
+    }
+
+    #[test]
+    fn test_resolve_priority() {
+        let project_skill = LoadedSkill {
+            file: create_mock_skill_file("shared"),
+            scope: SkillScope::Project,
+            namespace: None,
+        };
+        let personal_skill = LoadedSkill {
+            file: create_mock_skill_file("shared"),
+            scope: SkillScope::Personal,
+            namespace: None,
+        };
+
+        let skills = vec![project_skill, personal_skill];
+        let resolved = SkillLoader::resolve_priority(skills);
+
+        // Personal should win over project
+        assert_eq!(resolved.get("shared").unwrap().scope, SkillScope::Personal);
+    }
+
+    fn create_mock_skill_file(name: &str) -> SkillFile {
+        use crate::frontmatter::SkillFrontmatter;
+
+        SkillFile {
+            frontmatter: SkillFrontmatter {
+                name: Some(name.to_string()),
+                ..Default::default()
+            },
+            content: String::new(),
+            path: PathBuf::new(),
+            directory: PathBuf::new(),
+            supporting_files: Vec::new(),
+        }
+    }
+}

--- a/crates/thulp-skill-files/src/parser.rs
+++ b/crates/thulp-skill-files/src/parser.rs
@@ -1,0 +1,361 @@
+//! SKILL.md file parser.
+//!
+//! Parses SKILL.md files with optional YAML frontmatter and markdown content.
+
+use crate::error::{Result, SkillFileError};
+use crate::frontmatter::SkillFrontmatter;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+const FRONTMATTER_DELIMITER: &str = "---";
+
+/// A supporting file in the skill directory.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SupportingFile {
+    /// File name.
+    pub name: String,
+    /// Full path to the file.
+    pub path: PathBuf,
+    /// Classification of the file.
+    pub file_type: SupportingFileType,
+}
+
+/// Type classification for supporting files.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SupportingFileType {
+    /// Template files (.md, .txt in templates/).
+    Template,
+    /// Example files (in examples/).
+    Example,
+    /// Script files (in scripts/ or .sh/.py/.js).
+    Script,
+    /// Reference documentation (.md files).
+    Reference,
+    /// Other file types.
+    Other,
+}
+
+/// Parsed skill file with frontmatter and content.
+#[derive(Debug, Clone)]
+pub struct SkillFile {
+    /// Parsed YAML frontmatter.
+    pub frontmatter: SkillFrontmatter,
+
+    /// Markdown content (instructions).
+    pub content: String,
+
+    /// Path to the SKILL.md file.
+    pub path: PathBuf,
+
+    /// Directory containing the skill.
+    pub directory: PathBuf,
+
+    /// Supporting files discovered in the directory.
+    pub supporting_files: Vec<SupportingFile>,
+}
+
+impl SkillFile {
+    /// Parse a SKILL.md file from the given path.
+    pub fn parse<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path)?;
+
+        Self::parse_content(&content, path)
+    }
+
+    /// Parse SKILL.md content with path context.
+    pub fn parse_content(content: &str, path: &Path) -> Result<Self> {
+        let (frontmatter, body) = Self::split_frontmatter(content)?;
+
+        let directory = path
+            .parent()
+            .ok_or_else(|| SkillFileError::InvalidPath("No parent directory".into()))?
+            .to_path_buf();
+
+        let supporting_files = Self::discover_supporting_files(&directory)?;
+
+        Ok(Self {
+            frontmatter,
+            content: body,
+            path: path.to_path_buf(),
+            directory,
+            supporting_files,
+        })
+    }
+
+    /// Parse SKILL.md content without path context (for testing).
+    pub fn parse_content_only(content: &str) -> Result<(SkillFrontmatter, String)> {
+        Self::split_frontmatter(content)
+    }
+
+    /// Split content into frontmatter and body.
+    fn split_frontmatter(content: &str) -> Result<(SkillFrontmatter, String)> {
+        let trimmed = content.trim_start();
+
+        if !trimmed.starts_with(FRONTMATTER_DELIMITER) {
+            // No frontmatter, entire content is body
+            return Ok((SkillFrontmatter::default(), content.to_string()));
+        }
+
+        // Skip the opening delimiter and find the closing one
+        let rest = &trimmed[FRONTMATTER_DELIMITER.len()..];
+
+        // Skip any newline after opening delimiter
+        let rest = rest.trim_start_matches('\n').trim_start_matches('\r');
+
+        // Find the closing delimiter
+        let end_pos = rest
+            .find(FRONTMATTER_DELIMITER)
+            .ok_or_else(|| SkillFileError::Parse("Missing closing frontmatter delimiter".into()))?;
+
+        let yaml_content = rest[..end_pos].trim();
+        let body = rest[end_pos + FRONTMATTER_DELIMITER.len()..]
+            .trim_start_matches('\n')
+            .trim_start_matches('\r');
+
+        // Parse YAML, allowing empty frontmatter
+        let frontmatter: SkillFrontmatter = if yaml_content.is_empty() {
+            SkillFrontmatter::default()
+        } else {
+            serde_yaml::from_str(yaml_content)?
+        };
+
+        Ok((frontmatter, body.to_string()))
+    }
+
+    /// Discover supporting files in the skill directory.
+    fn discover_supporting_files(directory: &Path) -> Result<Vec<SupportingFile>> {
+        let mut files = Vec::new();
+
+        if !directory.exists() {
+            return Ok(files);
+        }
+
+        for entry in WalkDir::new(directory)
+            .max_depth(2)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if path.is_file() && path.file_name() != Some(std::ffi::OsStr::new("SKILL.md")) {
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let file_type = Self::classify_supporting_file(path, directory);
+
+                files.push(SupportingFile {
+                    name,
+                    path: path.to_path_buf(),
+                    file_type,
+                });
+            }
+        }
+
+        Ok(files)
+    }
+
+    /// Classify a supporting file by its location and extension.
+    fn classify_supporting_file(path: &Path, base: &Path) -> SupportingFileType {
+        let relative = path.strip_prefix(base).unwrap_or(path);
+        let components: Vec<_> = relative.components().collect();
+
+        // Check if file is in a special subdirectory
+        if components.len() > 1 {
+            let first_dir = components[0].as_os_str().to_str().unwrap_or("");
+            match first_dir {
+                "examples" => return SupportingFileType::Example,
+                "scripts" => return SupportingFileType::Script,
+                "templates" => return SupportingFileType::Template,
+                _ => {}
+            }
+        }
+
+        // Classify by extension
+        match path.extension().and_then(|e| e.to_str()) {
+            Some("md") => SupportingFileType::Reference,
+            Some("txt") => SupportingFileType::Template,
+            Some("sh") | Some("py") | Some("js") | Some("ts") => SupportingFileType::Script,
+            _ => SupportingFileType::Other,
+        }
+    }
+
+    /// Get effective name (from frontmatter or directory name).
+    pub fn effective_name(&self) -> String {
+        self.frontmatter.name.clone().unwrap_or_else(|| {
+            self.directory
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unnamed")
+                .to_string()
+        })
+    }
+
+    /// Get effective description (from frontmatter or first paragraph).
+    pub fn effective_description(&self) -> String {
+        self.frontmatter.description.clone().unwrap_or_else(|| {
+            // Extract first paragraph as description
+            self.content
+                .split("\n\n")
+                .next()
+                .unwrap_or("")
+                .lines()
+                .filter(|l| !l.starts_with('#'))
+                .collect::<Vec<_>>()
+                .join(" ")
+                .trim()
+                .to_string()
+        })
+    }
+
+    /// Check if a tool is allowed for this skill.
+    ///
+    /// Supports wildcard patterns with `*` which matches any characters.
+    /// Examples:
+    /// - `Bash` matches exactly `Bash`
+    /// - `Bash*` matches `Bash`, `Bash(python:test.py)`, etc.
+    /// - `Bash(python:*)` matches `Bash(python:foo)`, `Bash(python:bar)`, etc.
+    pub fn is_tool_allowed(&self, tool_name: &str) -> bool {
+        match &self.frontmatter.allowed_tools {
+            Some(allowed) => {
+                allowed.iter().any(|pattern| {
+                    if pattern.contains('*') {
+                        // Convert glob pattern to regex
+                        // Escape regex special chars except *, then replace * with .*
+                        let regex_pattern = regex::escape(pattern).replace(r"\*", ".*");
+                        regex::Regex::new(&format!("^{}$", regex_pattern))
+                            .map(|re| re.is_match(tool_name))
+                            .unwrap_or(false)
+                    } else {
+                        tool_name == pattern
+                    }
+                })
+            }
+            None => true, // No restrictions
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_no_frontmatter() {
+        let content = "# My Skill\n\nThis is the skill content.";
+        let (fm, body) = SkillFile::parse_content_only(content).unwrap();
+        assert!(fm.name.is_none());
+        assert!(body.contains("My Skill"));
+    }
+
+    #[test]
+    fn test_parse_with_frontmatter() {
+        let content = r#"---
+name: test-skill
+description: A test skill
+---
+# Instructions
+
+Do something useful.
+"#;
+        let (fm, body) = SkillFile::parse_content_only(content).unwrap();
+        assert_eq!(fm.name, Some("test-skill".to_string()));
+        assert_eq!(fm.description, Some("A test skill".to_string()));
+        assert!(body.contains("Instructions"));
+        assert!(body.contains("Do something useful"));
+    }
+
+    #[test]
+    fn test_parse_empty_frontmatter() {
+        let content = r#"---
+---
+# Just content here
+"#;
+        let (fm, body) = SkillFile::parse_content_only(content).unwrap();
+        assert!(fm.name.is_none());
+        assert!(body.contains("Just content here"));
+    }
+
+    #[test]
+    fn test_missing_closing_delimiter() {
+        let content = r#"---
+name: broken
+This has no closing delimiter
+"#;
+        let result = SkillFile::parse_content_only(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_allowed_exact_match() {
+        let content = r#"---
+allowed-tools:
+  - Read
+  - Write
+---
+Content
+"#;
+        let (fm, _) = SkillFile::parse_content_only(content).unwrap();
+        let skill = SkillFile {
+            frontmatter: fm,
+            content: String::new(),
+            path: PathBuf::new(),
+            directory: PathBuf::new(),
+            supporting_files: Vec::new(),
+        };
+
+        assert!(skill.is_tool_allowed("Read"));
+        assert!(skill.is_tool_allowed("Write"));
+        assert!(!skill.is_tool_allowed("Bash"));
+    }
+
+    #[test]
+    fn test_tool_allowed_wildcard() {
+        let content = r#"---
+allowed-tools:
+  - "Bash(python:*)"
+  - Read
+---
+Content
+"#;
+        let (fm, _) = SkillFile::parse_content_only(content).unwrap();
+        let skill = SkillFile {
+            frontmatter: fm,
+            content: String::new(),
+            path: PathBuf::new(),
+            directory: PathBuf::new(),
+            supporting_files: Vec::new(),
+        };
+
+        // Pattern "Bash(python:*)" matches "Bash(python:...)" - the * matches the inner content
+        assert!(skill.is_tool_allowed("Bash(python:test.py)"));
+        assert!(skill.is_tool_allowed("Bash(python:run.py)"));
+        assert!(skill.is_tool_allowed("Bash(python:)")); // Empty is ok too
+        assert!(!skill.is_tool_allowed("Bash(node:test.js)"));
+        assert!(!skill.is_tool_allowed("Bash")); // No parens, doesn't match
+        assert!(skill.is_tool_allowed("Read"));
+    }
+
+    #[test]
+    fn test_tool_allowed_no_restrictions() {
+        let content = r#"---
+name: unrestricted
+---
+Content
+"#;
+        let (fm, _) = SkillFile::parse_content_only(content).unwrap();
+        let skill = SkillFile {
+            frontmatter: fm,
+            content: String::new(),
+            path: PathBuf::new(),
+            directory: PathBuf::new(),
+            supporting_files: Vec::new(),
+        };
+
+        assert!(skill.is_tool_allowed("Anything"));
+        assert!(skill.is_tool_allowed("Read"));
+        assert!(skill.is_tool_allowed("Bash"));
+    }
+}

--- a/crates/thulp-skill-files/src/preprocessor.rs
+++ b/crates/thulp-skill-files/src/preprocessor.rs
@@ -1,0 +1,305 @@
+//! Preprocessor for skill content.
+//!
+//! Handles substitution of:
+//! - `$ARGUMENTS` - replaced with skill invocation arguments
+//! - `!`command`` - replaced with shell command output
+//! - `{{variable}}` - replaced with context values
+//! - `${ENV_VAR}` - replaced with environment variables
+
+use crate::error::{Result, SkillFileError};
+use regex::Regex;
+use std::collections::HashMap;
+
+/// Preprocessor for skill content.
+#[derive(Debug, Clone)]
+pub struct SkillPreprocessor {
+    /// Enable shell command execution.
+    pub enable_commands: bool,
+    /// Timeout for shell commands (seconds).
+    pub command_timeout: u64,
+    /// Enable environment variable substitution.
+    pub enable_env_vars: bool,
+}
+
+impl Default for SkillPreprocessor {
+    fn default() -> Self {
+        Self {
+            enable_commands: true,
+            command_timeout: 30,
+            enable_env_vars: true,
+        }
+    }
+}
+
+impl SkillPreprocessor {
+    /// Create a new preprocessor with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a preprocessor with commands disabled (safe mode).
+    pub fn safe() -> Self {
+        Self {
+            enable_commands: false,
+            enable_env_vars: false,
+            ..Default::default()
+        }
+    }
+
+    /// Preprocess skill content with arguments and commands.
+    ///
+    /// Processing order:
+    /// 1. `$ARGUMENTS` substitution
+    /// 2. `!`command`` execution (if enabled)
+    /// 3. `{{variable}}` context substitution
+    /// 4. `${ENV_VAR}` environment substitution (if enabled)
+    pub fn preprocess(
+        &self,
+        content: &str,
+        arguments: &str,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> Result<String> {
+        let mut result = content.to_string();
+
+        // Step 1: Replace $ARGUMENTS
+        result = self.substitute_arguments(&result, arguments);
+
+        // Step 2: Execute !`command` blocks
+        if self.enable_commands {
+            result = self.execute_commands(&result)?;
+        }
+
+        // Step 3: Replace {{variable}} placeholders from context
+        result = self.substitute_variables(&result, context)?;
+
+        // Step 4: Replace ${ENV_VAR} placeholders
+        if self.enable_env_vars {
+            result = self.substitute_env_vars(&result);
+        }
+
+        Ok(result)
+    }
+
+    /// Substitute $ARGUMENTS placeholder.
+    fn substitute_arguments(&self, content: &str, arguments: &str) -> String {
+        content.replace("$ARGUMENTS", arguments)
+    }
+
+    /// Execute !`command` blocks and replace with output.
+    fn execute_commands(&self, content: &str) -> Result<String> {
+        let re = Regex::new(r"!`([^`]+)`")?;
+        let mut result = content.to_string();
+        let mut errors = Vec::new();
+
+        // Collect all matches first to avoid borrowing issues
+        let matches: Vec<_> = re
+            .captures_iter(content)
+            .map(|cap| {
+                (
+                    cap.get(0).unwrap().as_str().to_string(),
+                    cap.get(1).unwrap().as_str().to_string(),
+                )
+            })
+            .collect();
+
+        for (full_match, command) in matches {
+            match self.run_shell_command(&command) {
+                Ok(output) => {
+                    result = result.replace(&full_match, &output);
+                }
+                Err(e) => {
+                    errors.push(format!("Command '{}': {}", command, e));
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(SkillFileError::CommandExecution(errors.join("; ")));
+        }
+
+        Ok(result)
+    }
+
+    /// Run a shell command and return its output.
+    fn run_shell_command(&self, command: &str) -> Result<String> {
+        #[cfg(target_os = "windows")]
+        let output = std::process::Command::new("cmd")
+            .args(["/C", command])
+            .output()
+            .map_err(|e| SkillFileError::CommandExecution(e.to_string()))?;
+
+        #[cfg(not(target_os = "windows"))]
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .output()
+            .map_err(|e| SkillFileError::CommandExecution(e.to_string()))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SkillFileError::CommandExecution(format!(
+                "Command failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// Substitute {{variable}} placeholders from context.
+    fn substitute_variables(
+        &self,
+        content: &str,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> Result<String> {
+        let re = Regex::new(r"\{\{([^}]+)\}\}")?;
+        let mut result = content.to_string();
+
+        // Collect all matches first
+        let matches: Vec<_> = re
+            .captures_iter(content)
+            .map(|cap| {
+                (
+                    cap.get(0).unwrap().as_str().to_string(),
+                    cap.get(1).unwrap().as_str().trim().to_string(),
+                )
+            })
+            .collect();
+
+        for (full_match, var_path) in matches {
+            if let Some(value) = self.resolve_path(&var_path, context) {
+                let value_str = match value {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Null => String::new(),
+                    other => serde_json::to_string(other).unwrap_or_default(),
+                };
+                result = result.replace(&full_match, &value_str);
+            }
+            // Leave unresolved variables as-is (they might be for later processing)
+        }
+
+        Ok(result)
+    }
+
+    /// Resolve a dotted path like "step_name.output.field".
+    fn resolve_path<'a>(
+        &self,
+        path: &str,
+        context: &'a HashMap<String, serde_json::Value>,
+    ) -> Option<&'a serde_json::Value> {
+        let parts: Vec<&str> = path.split('.').collect();
+
+        if parts.is_empty() {
+            return None;
+        }
+
+        let mut current = context.get(parts[0])?;
+
+        for part in &parts[1..] {
+            current = current.get(*part)?;
+        }
+
+        Some(current)
+    }
+
+    /// Substitute ${ENV_VAR} environment variables.
+    fn substitute_env_vars(&self, content: &str) -> String {
+        let re = Regex::new(r"\$\{([A-Z_][A-Z0-9_]*)\}").unwrap();
+
+        re.replace_all(content, |caps: &regex::Captures| {
+            let var_name = caps.get(1).unwrap().as_str();
+            std::env::var(var_name).unwrap_or_default()
+        })
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_substitute_arguments() {
+        let pp = SkillPreprocessor::new();
+        let result = pp.substitute_arguments("Process: $ARGUMENTS", "file.txt");
+        assert_eq!(result, "Process: file.txt");
+    }
+
+    #[test]
+    fn test_substitute_arguments_multiple() {
+        let pp = SkillPreprocessor::new();
+        let result = pp.substitute_arguments("First: $ARGUMENTS, Second: $ARGUMENTS", "hello");
+        assert_eq!(result, "First: hello, Second: hello");
+    }
+
+    #[test]
+    fn test_substitute_variables_simple() {
+        let pp = SkillPreprocessor::new();
+        let mut context = HashMap::new();
+        context.insert("name".to_string(), json!("Alice"));
+
+        let result = pp
+            .substitute_variables("Hello, {{name}}!", &context)
+            .unwrap();
+        assert_eq!(result, "Hello, Alice!");
+    }
+
+    #[test]
+    fn test_substitute_variables_nested() {
+        let pp = SkillPreprocessor::new();
+        let mut context = HashMap::new();
+        context.insert("user".to_string(), json!({"name": "Bob", "age": 30}));
+
+        let result = pp
+            .substitute_variables("Name: {{user.name}}, Age: {{user.age}}", &context)
+            .unwrap();
+        assert_eq!(result, "Name: Bob, Age: 30");
+    }
+
+    #[test]
+    fn test_substitute_variables_missing() {
+        let pp = SkillPreprocessor::new();
+        let context = HashMap::new();
+
+        let result = pp
+            .substitute_variables("Hello, {{missing}}!", &context)
+            .unwrap();
+        // Missing variables are left as-is
+        assert_eq!(result, "Hello, {{missing}}!");
+    }
+
+    #[test]
+    fn test_substitute_env_vars() {
+        let pp = SkillPreprocessor::new();
+        std::env::set_var("TEST_SKILL_VAR", "test_value");
+
+        let result = pp.substitute_env_vars("Value: ${TEST_SKILL_VAR}");
+        assert_eq!(result, "Value: test_value");
+
+        std::env::remove_var("TEST_SKILL_VAR");
+    }
+
+    #[test]
+    fn test_preprocess_combined() {
+        let pp = SkillPreprocessor::safe(); // Disable commands for test
+        let mut context = HashMap::new();
+        context.insert("project".to_string(), json!("myapp"));
+
+        let content = "Project: {{project}}\nArgs: $ARGUMENTS";
+        let result = pp.preprocess(content, "build --release", &context).unwrap();
+
+        assert_eq!(result, "Project: myapp\nArgs: build --release");
+    }
+
+    #[test]
+    fn test_command_execution_disabled() {
+        let pp = SkillPreprocessor::safe();
+        let context = HashMap::new();
+
+        // Command should not be executed, left as-is
+        let content = "Output: !`echo hello`";
+        let result = pp.preprocess(content, "", &context).unwrap();
+        assert_eq!(result, "Output: !`echo hello`");
+    }
+}

--- a/crates/thulp-skills/Cargo.toml
+++ b/crates/thulp-skills/Cargo.toml
@@ -24,6 +24,8 @@ serde_yaml = "0.9"
 tera = "1.20"
 thiserror = "2.0"
 async-trait = "0.1"
+tracing = "0.1"
+fastrand = "2.0"
 
 [features]
 default = []

--- a/crates/thulp-skills/src/config.rs
+++ b/crates/thulp-skills/src/config.rs
@@ -37,9 +37,9 @@ pub enum TimeoutAction {
 impl Default for TimeoutConfig {
     fn default() -> Self {
         Self {
-            skill_timeout: Duration::from_secs(300),  // 5 minutes
-            step_timeout: Duration::from_secs(60),    // 1 minute
-            tool_timeout: Duration::from_secs(30),    // 30 seconds
+            skill_timeout: Duration::from_secs(300), // 5 minutes
+            step_timeout: Duration::from_secs(60),   // 1 minute
+            tool_timeout: Duration::from_secs(30),   // 30 seconds
             timeout_action: TimeoutAction::Fail,
         }
     }

--- a/crates/thulp-skills/src/config.rs
+++ b/crates/thulp-skills/src/config.rs
@@ -1,0 +1,290 @@
+//! Configuration types for skill execution.
+//!
+//! This module provides configuration for timeouts and retries during skill execution.
+
+use std::time::Duration;
+
+/// Configuration for execution timeouts.
+#[derive(Debug, Clone)]
+pub struct TimeoutConfig {
+    /// Maximum time for entire skill execution.
+    pub skill_timeout: Duration,
+
+    /// Maximum time for a single step.
+    pub step_timeout: Duration,
+
+    /// Maximum time for a single tool call.
+    pub tool_timeout: Duration,
+
+    /// Action to take on timeout.
+    pub timeout_action: TimeoutAction,
+}
+
+/// Action to take when a timeout occurs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum TimeoutAction {
+    /// Fail immediately with an error.
+    #[default]
+    Fail,
+
+    /// Skip the timed-out step and continue execution.
+    Skip,
+
+    /// Return partial results collected so far.
+    Partial,
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            skill_timeout: Duration::from_secs(300),  // 5 minutes
+            step_timeout: Duration::from_secs(60),    // 1 minute
+            tool_timeout: Duration::from_secs(30),    // 30 seconds
+            timeout_action: TimeoutAction::Fail,
+        }
+    }
+}
+
+impl TimeoutConfig {
+    /// Create a new timeout configuration with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the skill timeout.
+    pub fn with_skill_timeout(mut self, timeout: Duration) -> Self {
+        self.skill_timeout = timeout;
+        self
+    }
+
+    /// Set the step timeout.
+    pub fn with_step_timeout(mut self, timeout: Duration) -> Self {
+        self.step_timeout = timeout;
+        self
+    }
+
+    /// Set the tool timeout.
+    pub fn with_tool_timeout(mut self, timeout: Duration) -> Self {
+        self.tool_timeout = timeout;
+        self
+    }
+
+    /// Set the timeout action.
+    pub fn with_timeout_action(mut self, action: TimeoutAction) -> Self {
+        self.timeout_action = action;
+        self
+    }
+}
+
+/// Configuration for retry behavior.
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts.
+    pub max_retries: usize,
+
+    /// Initial delay between retries.
+    pub initial_delay: Duration,
+
+    /// Maximum delay between retries (caps exponential backoff).
+    pub max_delay: Duration,
+
+    /// Backoff strategy to use.
+    pub backoff: BackoffStrategy,
+
+    /// Which error types are retryable.
+    pub retryable_errors: Vec<RetryableError>,
+}
+
+/// Strategy for calculating delay between retries.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum BackoffStrategy {
+    /// Fixed delay between retries.
+    Fixed,
+
+    /// Exponential backoff (delay * 2^attempt).
+    Exponential,
+
+    /// Exponential backoff with random jitter.
+    #[default]
+    ExponentialJitter,
+}
+
+/// Types of errors that can be retried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryableError {
+    /// Network or connection errors.
+    Network,
+
+    /// Rate limit errors (HTTP 429).
+    RateLimit,
+
+    /// Timeout errors.
+    Timeout,
+
+    /// Server errors (HTTP 5xx).
+    ServerError,
+
+    /// All errors are retryable.
+    All,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(10),
+            backoff: BackoffStrategy::ExponentialJitter,
+            retryable_errors: vec![
+                RetryableError::Network,
+                RetryableError::RateLimit,
+                RetryableError::Timeout,
+            ],
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Create a new retry configuration with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Disable retries.
+    pub fn no_retries() -> Self {
+        Self {
+            max_retries: 0,
+            ..Default::default()
+        }
+    }
+
+    /// Set the maximum number of retries.
+    pub fn with_max_retries(mut self, max: usize) -> Self {
+        self.max_retries = max;
+        self
+    }
+
+    /// Set the initial delay.
+    pub fn with_initial_delay(mut self, delay: Duration) -> Self {
+        self.initial_delay = delay;
+        self
+    }
+
+    /// Set the maximum delay.
+    pub fn with_max_delay(mut self, delay: Duration) -> Self {
+        self.max_delay = delay;
+        self
+    }
+
+    /// Set the backoff strategy.
+    pub fn with_backoff(mut self, strategy: BackoffStrategy) -> Self {
+        self.backoff = strategy;
+        self
+    }
+
+    /// Set which errors are retryable.
+    pub fn with_retryable_errors(mut self, errors: Vec<RetryableError>) -> Self {
+        self.retryable_errors = errors;
+        self
+    }
+
+    /// Make all errors retryable.
+    pub fn retry_all_errors(mut self) -> Self {
+        self.retryable_errors = vec![RetryableError::All];
+        self
+    }
+}
+
+/// Combined execution configuration.
+#[derive(Debug, Clone, Default)]
+pub struct ExecutionConfig {
+    /// Timeout configuration.
+    pub timeout: TimeoutConfig,
+
+    /// Retry configuration.
+    pub retry: RetryConfig,
+}
+
+impl ExecutionConfig {
+    /// Create a new execution configuration with defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set timeout configuration.
+    pub fn with_timeout(mut self, config: TimeoutConfig) -> Self {
+        self.timeout = config;
+        self
+    }
+
+    /// Set retry configuration.
+    pub fn with_retry(mut self, config: RetryConfig) -> Self {
+        self.retry = config;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timeout_config_defaults() {
+        let config = TimeoutConfig::default();
+        assert_eq!(config.skill_timeout, Duration::from_secs(300));
+        assert_eq!(config.step_timeout, Duration::from_secs(60));
+        assert_eq!(config.tool_timeout, Duration::from_secs(30));
+        assert_eq!(config.timeout_action, TimeoutAction::Fail);
+    }
+
+    #[test]
+    fn test_timeout_config_builder() {
+        let config = TimeoutConfig::new()
+            .with_skill_timeout(Duration::from_secs(120))
+            .with_step_timeout(Duration::from_secs(30))
+            .with_timeout_action(TimeoutAction::Skip);
+
+        assert_eq!(config.skill_timeout, Duration::from_secs(120));
+        assert_eq!(config.step_timeout, Duration::from_secs(30));
+        assert_eq!(config.timeout_action, TimeoutAction::Skip);
+    }
+
+    #[test]
+    fn test_retry_config_defaults() {
+        let config = RetryConfig::default();
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.initial_delay, Duration::from_millis(100));
+        assert_eq!(config.backoff, BackoffStrategy::ExponentialJitter);
+        assert!(config.retryable_errors.contains(&RetryableError::Network));
+    }
+
+    #[test]
+    fn test_retry_config_no_retries() {
+        let config = RetryConfig::no_retries();
+        assert_eq!(config.max_retries, 0);
+    }
+
+    #[test]
+    fn test_retry_config_builder() {
+        let config = RetryConfig::new()
+            .with_max_retries(5)
+            .with_initial_delay(Duration::from_millis(200))
+            .with_backoff(BackoffStrategy::Fixed)
+            .retry_all_errors();
+
+        assert_eq!(config.max_retries, 5);
+        assert_eq!(config.initial_delay, Duration::from_millis(200));
+        assert_eq!(config.backoff, BackoffStrategy::Fixed);
+        assert!(config.retryable_errors.contains(&RetryableError::All));
+    }
+
+    #[test]
+    fn test_execution_config() {
+        let config = ExecutionConfig::new()
+            .with_timeout(TimeoutConfig::new().with_skill_timeout(Duration::from_secs(60)))
+            .with_retry(RetryConfig::no_retries());
+
+        assert_eq!(config.timeout.skill_timeout, Duration::from_secs(60));
+        assert_eq!(config.retry.max_retries, 0);
+    }
+}

--- a/crates/thulp-skills/src/default_executor.rs
+++ b/crates/thulp-skills/src/default_executor.rs
@@ -1,0 +1,820 @@
+//! Default skill executor implementation.
+//!
+//! This module provides [`DefaultSkillExecutor`], the standard implementation
+//! of [`SkillExecutor`] that executes skills using a [`Transport`].
+//!
+//! # Example
+//!
+//! ```ignore
+//! use thulp_skills::{DefaultSkillExecutor, ExecutionContext, NoOpHooks};
+//! use thulp_core::Transport;
+//!
+//! let executor = DefaultSkillExecutor::new(transport);
+//! let mut context = ExecutionContext::new()
+//!     .with_input("query", json!("search term"));
+//!
+//! let result = executor.execute(&skill, &mut context).await?;
+//! ```
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use thulp_core::{ToolCall, ToolResult, Transport};
+
+use crate::{
+    calculate_delay, is_error_retryable, ExecutionConfig, ExecutionContext, ExecutionHooks,
+    NoOpHooks, RetryConfig, RetryableError, Skill, SkillError, SkillExecutor, SkillResult,
+    SkillStep, StepResult, TimeoutAction,
+};
+
+/// Default skill executor that uses a [`Transport`] to execute tool calls.
+///
+/// This executor implements the standard skill execution flow:
+/// 1. Execute steps sequentially
+/// 2. Apply timeout and retry logic per step
+/// 3. Propagate outputs from earlier steps to later steps
+/// 4. Invoke lifecycle hooks at appropriate points
+///
+/// # Type Parameters
+///
+/// * `T` - The transport type for executing tool calls
+/// * `H` - The hooks type for lifecycle callbacks (defaults to [`NoOpHooks`])
+///
+/// # Example
+///
+/// ```ignore
+/// use thulp_skills::{DefaultSkillExecutor, ExecutionContext, TracingHooks};
+///
+/// // With default no-op hooks
+/// let executor = DefaultSkillExecutor::new(transport);
+///
+/// // With tracing hooks
+/// let executor = DefaultSkillExecutor::with_hooks(transport, TracingHooks::new());
+///
+/// let mut context = ExecutionContext::new()
+///     .with_input("query", json!("test"));
+///
+/// let result = executor.execute(&skill, &mut context).await?;
+/// ```
+pub struct DefaultSkillExecutor<T, H = NoOpHooks> {
+    transport: Arc<T>,
+    hooks: Arc<H>,
+}
+
+impl<T: Transport> DefaultSkillExecutor<T, NoOpHooks> {
+    /// Create a new executor with the given transport and no-op hooks.
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport: Arc::new(transport),
+            hooks: Arc::new(NoOpHooks),
+        }
+    }
+}
+
+impl<T: Transport, H: ExecutionHooks> DefaultSkillExecutor<T, H> {
+    /// Create a new executor with the given transport and hooks.
+    pub fn with_hooks(transport: T, hooks: H) -> Self {
+        Self {
+            transport: Arc::new(transport),
+            hooks: Arc::new(hooks),
+        }
+    }
+
+    /// Create a new executor from Arc-wrapped transport and hooks.
+    ///
+    /// This is useful when you want to share the transport or hooks
+    /// across multiple executors.
+    pub fn from_arcs(transport: Arc<T>, hooks: Arc<H>) -> Self {
+        Self { transport, hooks }
+    }
+
+    /// Get a reference to the transport.
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+
+    /// Get a reference to the hooks.
+    pub fn hooks(&self) -> &H {
+        &self.hooks
+    }
+
+    /// Prepare arguments by substituting context variables.
+    ///
+    /// This handles two cases:
+    /// 1. Entire string values like `"{{var}}"` → replaced with actual JSON value
+    /// 2. Embedded placeholders like `"prefix {{var}} suffix"` → string interpolation
+    fn prepare_arguments(
+        &self,
+        args: &Value,
+        context: &ExecutionContext,
+    ) -> Result<Value, SkillError> {
+        self.substitute_value(args, &context.variables())
+    }
+
+    /// Recursively substitute variables in a JSON value.
+    fn substitute_value(
+        &self,
+        value: &Value,
+        variables: &std::collections::HashMap<String, Value>,
+    ) -> Result<Value, SkillError> {
+        match value {
+            Value::String(s) => {
+                // Check if the entire string is a single placeholder like "{{var}}"
+                let trimmed = s.trim();
+                if trimmed.starts_with("{{") && trimmed.ends_with("}}") {
+                    let inner = &trimmed[2..trimmed.len() - 2];
+                    // Check if it's a simple variable reference (no other text)
+                    if !inner.contains("{{") && !inner.contains("}}") {
+                        let var_name = inner.trim();
+                        if let Some(var_value) = variables.get(var_name) {
+                            return Ok(var_value.clone());
+                        }
+                    }
+                }
+
+                // Otherwise, do string interpolation
+                let mut result = s.clone();
+                for (key, var_value) in variables {
+                    let placeholder = format!("{{{{{}}}}}", key);
+                    if result.contains(&placeholder) {
+                        // For string interpolation, convert value to string representation
+                        let replacement = match var_value {
+                            Value::String(s) => s.clone(),
+                            Value::Null => "null".to_string(),
+                            Value::Bool(b) => b.to_string(),
+                            Value::Number(n) => n.to_string(),
+                            _ => serde_json::to_string(var_value).map_err(|e| {
+                                SkillError::InvalidConfig(format!(
+                                    "Failed to serialize value: {}",
+                                    e
+                                ))
+                            })?,
+                        };
+                        result = result.replace(&placeholder, &replacement);
+                    }
+                }
+                Ok(Value::String(result))
+            }
+            Value::Array(arr) => {
+                let substituted: Result<Vec<Value>, SkillError> = arr
+                    .iter()
+                    .map(|v| self.substitute_value(v, variables))
+                    .collect();
+                Ok(Value::Array(substituted?))
+            }
+            Value::Object(obj) => {
+                let mut new_obj = serde_json::Map::new();
+                for (k, v) in obj {
+                    new_obj.insert(k.clone(), self.substitute_value(v, variables)?);
+                }
+                Ok(Value::Object(new_obj))
+            }
+            // Numbers, booleans, nulls pass through unchanged
+            _ => Ok(value.clone()),
+        }
+    }
+
+    /// Execute a single step with timeout and retry logic.
+    async fn execute_step_with_retry_timeout(
+        &self,
+        tool_call: &ToolCall,
+        step: &SkillStep,
+        timeout: Duration,
+        retry_config: &RetryConfig,
+        context: &ExecutionContext,
+    ) -> Result<(ToolResult, usize), SkillError> {
+        let mut attempts = 0;
+
+        loop {
+            attempts += 1;
+
+            // Execute with timeout
+            let result = tokio::time::timeout(timeout, self.transport.call(tool_call)).await;
+
+            match result {
+                Ok(Ok(tool_result)) => {
+                    // Success!
+                    return Ok((tool_result, attempts - 1)); // attempts-1 = retry count
+                }
+                Ok(Err(e)) => {
+                    // Transport error - check if retryable
+                    let error_msg = e.to_string();
+
+                    if attempts > retry_config.max_retries
+                        || !is_error_retryable(&error_msg, retry_config)
+                    {
+                        return Err(SkillError::RetryExhausted {
+                            step: step.name.clone(),
+                            attempts,
+                            message: error_msg,
+                        });
+                    }
+
+                    // Notify hooks about retry
+                    self.hooks.on_retry(step, attempts, &error_msg, context);
+
+                    let delay = calculate_delay(retry_config, attempts);
+                    tracing::warn!(
+                        step = %step.name,
+                        attempt = attempts,
+                        max_retries = retry_config.max_retries,
+                        delay_ms = delay.as_millis() as u64,
+                        error = %e,
+                        "Retrying step after error"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(_elapsed) => {
+                    // Timeout - notify hooks
+                    self.hooks
+                        .on_timeout(step, timeout.as_millis() as u64, context);
+
+                    // Check if retryable
+                    if attempts > retry_config.max_retries
+                        || !retry_config
+                            .retryable_errors
+                            .contains(&RetryableError::Timeout)
+                    {
+                        return Err(SkillError::StepTimeout {
+                            step: step.name.clone(),
+                            duration: timeout,
+                        });
+                    }
+
+                    // Notify hooks about retry
+                    self.hooks.on_retry(step, attempts, "timeout", context);
+
+                    let delay = calculate_delay(retry_config, attempts);
+                    tracing::warn!(
+                        step = %step.name,
+                        attempt = attempts,
+                        max_retries = retry_config.max_retries,
+                        delay_ms = delay.as_millis() as u64,
+                        "Retrying step after timeout"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl<T: Transport, H: ExecutionHooks> SkillExecutor for DefaultSkillExecutor<T, H> {
+    async fn execute(
+        &self,
+        skill: &Skill,
+        context: &mut ExecutionContext,
+    ) -> Result<SkillResult, SkillError> {
+        // Notify hooks
+        self.hooks.before_skill(skill, context);
+
+        let config = context.config().clone();
+        let skill_timeout = config.timeout.skill_timeout;
+
+        // Wrap entire execution in skill-level timeout
+        let result = tokio::time::timeout(skill_timeout, async {
+            self.execute_steps(skill, context, &config).await
+        })
+        .await;
+
+        let skill_result = match result {
+            Ok(inner_result) => inner_result,
+            Err(_elapsed) => {
+                // Handle based on timeout action
+                match config.timeout.timeout_action {
+                    TimeoutAction::Fail => {
+                        let error = SkillError::SkillTimeout {
+                            duration: skill_timeout,
+                        };
+                        self.hooks.on_error(&error, context);
+                        Err(error)
+                    }
+                    TimeoutAction::Skip | TimeoutAction::Partial => {
+                        // Return partial result
+                        Ok(SkillResult {
+                            success: false,
+                            step_results: vec![],
+                            output: None,
+                            error: Some(format!("Skill timed out after {:?}", skill_timeout)),
+                        })
+                    }
+                }
+            }
+        };
+
+        // Notify hooks with result
+        match &skill_result {
+            Ok(result) => {
+                self.hooks.after_skill(skill, result, context);
+            }
+            Err(e) => {
+                self.hooks.on_error(e, context);
+                // Still call after_skill with a failure result
+                let failure_result = SkillResult {
+                    success: false,
+                    step_results: vec![],
+                    output: None,
+                    error: Some(e.to_string()),
+                };
+                self.hooks.after_skill(skill, &failure_result, context);
+            }
+        }
+
+        skill_result
+    }
+
+    async fn execute_step(
+        &self,
+        step: &SkillStep,
+        context: &mut ExecutionContext,
+    ) -> Result<StepResult, SkillError> {
+        let config = context.config().clone();
+
+        // Determine timeout for this step
+        let step_timeout = step
+            .timeout_secs
+            .map(Duration::from_secs)
+            .unwrap_or(config.timeout.step_timeout);
+
+        // Determine max retries for this step
+        let max_retries = step.max_retries.unwrap_or(config.retry.max_retries);
+        let step_retry_config = RetryConfig {
+            max_retries,
+            ..config.retry.clone()
+        };
+
+        // Prepare arguments
+        let prepared_args = self.prepare_arguments(&step.arguments, context)?;
+
+        let tool_call = ToolCall {
+            tool: step.tool.clone(),
+            arguments: prepared_args,
+        };
+
+        // Notify hooks
+        self.hooks.before_step(step, 0, context);
+
+        let start = Instant::now();
+
+        // Execute with retry and timeout
+        let result = self
+            .execute_step_with_retry_timeout(
+                &tool_call,
+                step,
+                step_timeout,
+                &step_retry_config,
+                context,
+            )
+            .await;
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        let step_result = match result {
+            Ok((tool_result, retry_attempts)) => {
+                // Store output in context
+                if let Some(data) = &tool_result.data {
+                    context.set_output(step.name.clone(), data.clone());
+                }
+
+                let is_success = tool_result.is_success();
+                StepResult {
+                    step_name: step.name.clone(),
+                    success: is_success,
+                    output: tool_result.data,
+                    error: if is_success { None } else { tool_result.error },
+                    duration_ms,
+                    retry_attempts,
+                }
+            }
+            Err(e) => {
+                self.hooks.on_error(&e, context);
+
+                StepResult {
+                    step_name: step.name.clone(),
+                    success: false,
+                    output: None,
+                    error: Some(e.to_string()),
+                    duration_ms,
+                    retry_attempts: 0,
+                }
+            }
+        };
+
+        // Notify hooks
+        self.hooks.after_step(step, 0, &step_result, context);
+
+        if step_result.success {
+            Ok(step_result)
+        } else {
+            // Return the step result even on failure for continue_on_error support
+            Err(SkillError::Execution(
+                step_result.error.clone().unwrap_or_default(),
+            ))
+        }
+    }
+}
+
+impl<T: Transport, H: ExecutionHooks> DefaultSkillExecutor<T, H> {
+    /// Internal method to execute all steps (used within skill timeout).
+    async fn execute_steps(
+        &self,
+        skill: &Skill,
+        context: &mut ExecutionContext,
+        config: &ExecutionConfig,
+    ) -> Result<SkillResult, SkillError> {
+        let mut step_results: Vec<(String, ToolResult)> = Vec::new();
+
+        for (index, step) in skill.steps.iter().enumerate() {
+            // Determine timeout for this step
+            let step_timeout = step
+                .timeout_secs
+                .map(Duration::from_secs)
+                .unwrap_or(config.timeout.step_timeout);
+
+            // Determine max retries for this step
+            let max_retries = step.max_retries.unwrap_or(config.retry.max_retries);
+            let step_retry_config = RetryConfig {
+                max_retries,
+                ..config.retry.clone()
+            };
+
+            // Prepare arguments
+            let prepared_args = self.prepare_arguments(&step.arguments, context)?;
+
+            let tool_call = ToolCall {
+                tool: step.tool.clone(),
+                arguments: prepared_args,
+            };
+
+            // Notify hooks
+            self.hooks.before_step(step, index, context);
+
+            let start = Instant::now();
+
+            // Execute with retry and timeout
+            let step_result = self
+                .execute_step_with_retry_timeout(
+                    &tool_call,
+                    step,
+                    step_timeout,
+                    &step_retry_config,
+                    context,
+                )
+                .await;
+
+            let duration_ms = start.elapsed().as_millis() as u64;
+
+            match step_result {
+                Ok((tool_result, retry_attempts)) => {
+                    // Create StepResult for hooks
+                    let sr = StepResult {
+                        step_name: step.name.clone(),
+                        success: true,
+                        output: tool_result.data.clone(),
+                        error: None,
+                        duration_ms,
+                        retry_attempts,
+                    };
+                    self.hooks.after_step(step, index, &sr, context);
+
+                    step_results.push((step.name.clone(), tool_result.clone()));
+
+                    // Add result to context for use in subsequent steps
+                    context.set_output(
+                        step.name.clone(),
+                        tool_result.data.clone().unwrap_or(Value::Null),
+                    );
+
+                    // If this is the last step, use its result as output
+                    if step_results.len() == skill.steps.len() {
+                        return Ok(SkillResult {
+                            success: true,
+                            step_results,
+                            output: tool_result.data,
+                            error: None,
+                        });
+                    }
+                }
+                Err(e) => {
+                    // Create StepResult for hooks
+                    let sr = StepResult::failure(&step.name, e.to_string(), duration_ms);
+                    self.hooks.after_step(step, index, &sr, context);
+                    self.hooks.on_error(&e, context);
+
+                    if step.continue_on_error {
+                        // Continue on error
+                        step_results.push((step.name.clone(), ToolResult::failure(e.to_string())));
+                    } else {
+                        // Check timeout action for Skip/Partial behavior
+                        match &config.timeout.timeout_action {
+                            TimeoutAction::Skip => {
+                                step_results
+                                    .push((step.name.clone(), ToolResult::failure(e.to_string())));
+                                // Continue to next step
+                            }
+                            TimeoutAction::Partial => {
+                                return Ok(SkillResult {
+                                    success: false,
+                                    step_results,
+                                    output: None,
+                                    error: Some(e.to_string()),
+                                });
+                            }
+                            TimeoutAction::Fail => {
+                                return Err(e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(SkillResult {
+            success: true,
+            step_results,
+            output: None,
+            error: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Mock transport for testing
+    struct MockTransport {
+        responses: HashMap<String, ToolResult>,
+    }
+
+    impl MockTransport {
+        fn new() -> Self {
+            Self {
+                responses: HashMap::new(),
+            }
+        }
+
+        fn with_response(mut self, tool_name: &str, result: ToolResult) -> Self {
+            self.responses.insert(tool_name.to_string(), result);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl Transport for MockTransport {
+        async fn connect(&mut self) -> thulp_core::Result<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&mut self) -> thulp_core::Result<()> {
+            Ok(())
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        async fn list_tools(&self) -> thulp_core::Result<Vec<thulp_core::ToolDefinition>> {
+            Ok(vec![])
+        }
+
+        async fn call(&self, call: &ToolCall) -> thulp_core::Result<ToolResult> {
+            if let Some(result) = self.responses.get(&call.tool) {
+                Ok(result.clone())
+            } else {
+                Err(thulp_core::Error::ToolNotFound(call.tool.clone()))
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_default_executor_basic() {
+        let transport = MockTransport::new().with_response(
+            "tool1",
+            ToolResult::success(serde_json::json!({"result": 1})),
+        );
+
+        let executor = DefaultSkillExecutor::new(transport);
+
+        let skill = Skill::new("test", "Test skill").with_step(SkillStep {
+            name: "step1".to_string(),
+            tool: "tool1".to_string(),
+            arguments: serde_json::json!({}),
+            continue_on_error: false,
+            timeout_secs: None,
+            max_retries: None,
+        });
+
+        let mut context = ExecutionContext::new();
+        let result = executor.execute(&skill, &mut context).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.step_results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_default_executor_with_hooks() {
+        struct CountingHooks {
+            before_skill_count: Arc<AtomicUsize>,
+            after_skill_count: Arc<AtomicUsize>,
+            before_step_count: Arc<AtomicUsize>,
+            after_step_count: Arc<AtomicUsize>,
+        }
+
+        impl ExecutionHooks for CountingHooks {
+            fn before_skill(&self, _skill: &Skill, _context: &ExecutionContext) {
+                self.before_skill_count.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn after_skill(
+                &self,
+                _skill: &Skill,
+                _result: &SkillResult,
+                _context: &ExecutionContext,
+            ) {
+                self.after_skill_count.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn before_step(
+                &self,
+                _step: &SkillStep,
+                _step_index: usize,
+                _context: &ExecutionContext,
+            ) {
+                self.before_step_count.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn after_step(
+                &self,
+                _step: &SkillStep,
+                _step_index: usize,
+                _result: &StepResult,
+                _context: &ExecutionContext,
+            ) {
+                self.after_step_count.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let before_skill = Arc::new(AtomicUsize::new(0));
+        let after_skill = Arc::new(AtomicUsize::new(0));
+        let before_step = Arc::new(AtomicUsize::new(0));
+        let after_step = Arc::new(AtomicUsize::new(0));
+
+        let hooks = CountingHooks {
+            before_skill_count: before_skill.clone(),
+            after_skill_count: after_skill.clone(),
+            before_step_count: before_step.clone(),
+            after_step_count: after_step.clone(),
+        };
+
+        let transport = MockTransport::new()
+            .with_response("tool1", ToolResult::success(serde_json::json!({})))
+            .with_response("tool2", ToolResult::success(serde_json::json!({})));
+
+        let executor = DefaultSkillExecutor::with_hooks(transport, hooks);
+
+        let skill = Skill::new("test", "Test skill")
+            .with_step(SkillStep {
+                name: "step1".to_string(),
+                tool: "tool1".to_string(),
+                arguments: serde_json::json!({}),
+                continue_on_error: false,
+                timeout_secs: None,
+                max_retries: None,
+            })
+            .with_step(SkillStep {
+                name: "step2".to_string(),
+                tool: "tool2".to_string(),
+                arguments: serde_json::json!({}),
+                continue_on_error: false,
+                timeout_secs: None,
+                max_retries: None,
+            });
+
+        let mut context = ExecutionContext::new();
+        let result = executor.execute(&skill, &mut context).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(before_skill.load(Ordering::SeqCst), 1);
+        assert_eq!(after_skill.load(Ordering::SeqCst), 1);
+        assert_eq!(before_step.load(Ordering::SeqCst), 2);
+        assert_eq!(after_step.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_default_executor_context_propagation() {
+        let transport = MockTransport::new()
+            .with_response(
+                "step1_tool",
+                ToolResult::success(serde_json::json!({"value": 42})),
+            )
+            .with_response(
+                "step2_tool",
+                ToolResult::success(serde_json::json!({"doubled": 84})),
+            );
+
+        let executor = DefaultSkillExecutor::new(transport);
+
+        let skill = Skill::new("test", "Test skill")
+            .with_step(SkillStep {
+                name: "step1".to_string(),
+                tool: "step1_tool".to_string(),
+                arguments: serde_json::json!({}),
+                continue_on_error: false,
+                timeout_secs: None,
+                max_retries: None,
+            })
+            .with_step(SkillStep {
+                name: "step2".to_string(),
+                tool: "step2_tool".to_string(),
+                arguments: serde_json::json!({"input": "{{step1}}"}),
+                continue_on_error: false,
+                timeout_secs: None,
+                max_retries: None,
+            });
+
+        let mut context = ExecutionContext::new();
+        let result = executor.execute(&skill, &mut context).await.unwrap();
+
+        assert!(result.success);
+
+        // Check that step1 output was stored in context
+        assert!(context.get_output("step1").is_some());
+        assert!(context.get_output("step2").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_default_executor_continue_on_error() {
+        let transport = MockTransport::new()
+            // step1 will fail (no response configured)
+            .with_response(
+                "step2_tool",
+                ToolResult::success(serde_json::json!({"ok": true})),
+            );
+
+        let executor = DefaultSkillExecutor::new(transport);
+
+        let skill = Skill::new("test", "Test skill")
+            .with_step(SkillStep {
+                name: "step1".to_string(),
+                tool: "step1_tool".to_string(),
+                arguments: serde_json::json!({}),
+                continue_on_error: true, // Should continue even if this fails
+                timeout_secs: None,
+                max_retries: Some(0),
+            })
+            .with_step(SkillStep {
+                name: "step2".to_string(),
+                tool: "step2_tool".to_string(),
+                arguments: serde_json::json!({}),
+                continue_on_error: false,
+                timeout_secs: None,
+                max_retries: None,
+            });
+
+        let config = ExecutionConfig::new().with_retry(crate::RetryConfig::no_retries());
+        let mut context = ExecutionContext::new().with_config(config);
+
+        let result = executor.execute(&skill, &mut context).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.step_results.len(), 2);
+
+        // First step should have failed
+        let (_, step1_result) = &result.step_results[0];
+        assert!(!step1_result.is_success());
+
+        // Second step should have succeeded
+        let (_, step2_result) = &result.step_results[1];
+        assert!(step2_result.is_success());
+    }
+
+    #[tokio::test]
+    async fn test_default_executor_from_arcs() {
+        let transport = Arc::new(
+            MockTransport::new().with_response("tool", ToolResult::success(serde_json::json!({}))),
+        );
+        let hooks = Arc::new(NoOpHooks);
+
+        let executor = DefaultSkillExecutor::from_arcs(transport.clone(), hooks.clone());
+
+        let skill = Skill::new("test", "Test").with_step(SkillStep {
+            name: "s".to_string(),
+            tool: "tool".to_string(),
+            arguments: serde_json::json!({}),
+            continue_on_error: false,
+            timeout_secs: None,
+            max_retries: None,
+        });
+
+        let mut context = ExecutionContext::new();
+        let result = executor.execute(&skill, &mut context).await.unwrap();
+
+        assert!(result.success);
+    }
+}

--- a/crates/thulp-skills/src/executor.rs
+++ b/crates/thulp-skills/src/executor.rs
@@ -1,0 +1,416 @@
+//! Skill execution abstraction.
+//!
+//! This module provides the [`SkillExecutor`] trait for pluggable skill execution,
+//! along with [`ExecutionContext`] for managing state between steps.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use thulp_skills::{SkillExecutor, ExecutionContext, DefaultSkillExecutor};
+//!
+//! let executor = DefaultSkillExecutor::new(transport);
+//! let mut context = ExecutionContext::new()
+//!     .with_input("query", json!("search term"));
+//!
+//! let result = executor.execute(&skill, &mut context).await?;
+//! ```
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::{ExecutionConfig, Skill, SkillError, SkillResult, SkillStep};
+
+/// Result of executing a single step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepResult {
+    /// Name of the step that was executed
+    pub step_name: String,
+
+    /// Whether the step completed successfully
+    pub success: bool,
+
+    /// Output data from the step
+    pub output: Option<Value>,
+
+    /// Error message if the step failed
+    pub error: Option<String>,
+
+    /// Duration of the step execution in milliseconds
+    pub duration_ms: u64,
+
+    /// Number of retry attempts made
+    pub retry_attempts: usize,
+}
+
+impl StepResult {
+    /// Create a successful step result.
+    pub fn success(step_name: impl Into<String>, output: Option<Value>, duration_ms: u64) -> Self {
+        Self {
+            step_name: step_name.into(),
+            success: true,
+            output,
+            error: None,
+            duration_ms,
+            retry_attempts: 0,
+        }
+    }
+
+    /// Create a failed step result.
+    pub fn failure(
+        step_name: impl Into<String>,
+        error: impl Into<String>,
+        duration_ms: u64,
+    ) -> Self {
+        Self {
+            step_name: step_name.into(),
+            success: false,
+            output: None,
+            error: Some(error.into()),
+            duration_ms,
+            retry_attempts: 0,
+        }
+    }
+
+    /// Set the number of retry attempts.
+    pub fn with_retry_attempts(mut self, attempts: usize) -> Self {
+        self.retry_attempts = attempts;
+        self
+    }
+}
+
+/// Context passed through skill execution, carrying inputs, outputs, and configuration.
+///
+/// The execution context maintains state between steps, allowing later steps to
+/// reference outputs from earlier steps.
+#[derive(Debug, Clone)]
+pub struct ExecutionContext {
+    /// Input arguments provided to the skill
+    inputs: HashMap<String, Value>,
+
+    /// Outputs from completed steps, keyed by step name
+    outputs: HashMap<String, Value>,
+
+    /// Execution configuration (timeouts, retries, etc.)
+    config: ExecutionConfig,
+
+    /// Optional metadata for tracking/debugging
+    metadata: HashMap<String, Value>,
+}
+
+impl Default for ExecutionContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExecutionContext {
+    /// Create a new empty execution context with default configuration.
+    pub fn new() -> Self {
+        Self {
+            inputs: HashMap::new(),
+            outputs: HashMap::new(),
+            config: ExecutionConfig::default(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Create a context from input arguments.
+    pub fn from_inputs(inputs: HashMap<String, Value>) -> Self {
+        Self {
+            inputs,
+            outputs: HashMap::new(),
+            config: ExecutionConfig::default(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Add an input value.
+    pub fn with_input(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.inputs.insert(key.into(), value);
+        self
+    }
+
+    /// Set the execution configuration.
+    pub fn with_config(mut self, config: ExecutionConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Add metadata.
+    pub fn with_metadata(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
+    }
+
+    /// Get an input value by key.
+    pub fn get_input(&self, key: &str) -> Option<&Value> {
+        self.inputs.get(key)
+    }
+
+    /// Get all inputs.
+    pub fn inputs(&self) -> &HashMap<String, Value> {
+        &self.inputs
+    }
+
+    /// Get an output value by step name.
+    pub fn get_output(&self, step_name: &str) -> Option<&Value> {
+        self.outputs.get(step_name)
+    }
+
+    /// Get all outputs.
+    pub fn outputs(&self) -> &HashMap<String, Value> {
+        &self.outputs
+    }
+
+    /// Set an output value for a step.
+    pub fn set_output(&mut self, step_name: impl Into<String>, value: Value) {
+        self.outputs.insert(step_name.into(), value);
+    }
+
+    /// Get the execution configuration.
+    pub fn config(&self) -> &ExecutionConfig {
+        &self.config
+    }
+
+    /// Get mutable reference to the execution configuration.
+    pub fn config_mut(&mut self) -> &mut ExecutionConfig {
+        &mut self.config
+    }
+
+    /// Get metadata value.
+    pub fn get_metadata(&self, key: &str) -> Option<&Value> {
+        self.metadata.get(key)
+    }
+
+    /// Get all metadata.
+    pub fn metadata(&self) -> &HashMap<String, Value> {
+        &self.metadata
+    }
+
+    /// Set metadata value.
+    pub fn set_metadata(&mut self, key: impl Into<String>, value: Value) {
+        self.metadata.insert(key.into(), value);
+    }
+
+    /// Get a combined view of inputs and outputs for variable substitution.
+    ///
+    /// Outputs take precedence over inputs if there are key conflicts.
+    pub fn variables(&self) -> HashMap<String, Value> {
+        let mut vars = self.inputs.clone();
+        vars.extend(self.outputs.clone());
+        vars
+    }
+
+    /// Clear all outputs (useful for re-execution).
+    pub fn clear_outputs(&mut self) {
+        self.outputs.clear();
+    }
+}
+
+/// Trait for executing skills.
+///
+/// This trait abstracts the execution of skills, allowing different implementations
+/// to handle execution in different ways (e.g., local execution, remote execution,
+/// cached execution, etc.).
+///
+/// # Example
+///
+/// ```ignore
+/// use thulp_skills::{SkillExecutor, ExecutionContext};
+///
+/// struct MyExecutor;
+///
+/// #[async_trait]
+/// impl SkillExecutor for MyExecutor {
+///     async fn execute(
+///         &self,
+///         skill: &Skill,
+///         context: &mut ExecutionContext,
+///     ) -> Result<SkillResult, SkillError> {
+///         // Custom execution logic
+///     }
+///
+///     async fn execute_step(
+///         &self,
+///         step: &SkillStep,
+///         context: &mut ExecutionContext,
+///     ) -> Result<StepResult, SkillError> {
+///         // Custom step execution logic
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait SkillExecutor: Send + Sync {
+    /// Execute a complete skill.
+    ///
+    /// This method executes all steps in the skill sequentially, passing
+    /// outputs from earlier steps to later steps via the context.
+    ///
+    /// # Arguments
+    ///
+    /// * `skill` - The skill to execute
+    /// * `context` - Mutable execution context for inputs/outputs
+    ///
+    /// # Returns
+    ///
+    /// A `SkillResult` containing the outcome of all steps.
+    async fn execute(
+        &self,
+        skill: &Skill,
+        context: &mut ExecutionContext,
+    ) -> Result<SkillResult, SkillError>;
+
+    /// Execute a single step.
+    ///
+    /// This method executes a single step from a skill workflow.
+    ///
+    /// # Arguments
+    ///
+    /// * `step` - The step to execute
+    /// * `context` - Mutable execution context for inputs/outputs
+    ///
+    /// # Returns
+    ///
+    /// A `StepResult` containing the outcome of the step.
+    async fn execute_step(
+        &self,
+        step: &SkillStep,
+        context: &mut ExecutionContext,
+    ) -> Result<StepResult, SkillError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_step_result_success() {
+        let result = StepResult::success("step1", Some(serde_json::json!({"data": "test"})), 100);
+
+        assert!(result.success);
+        assert_eq!(result.step_name, "step1");
+        assert!(result.output.is_some());
+        assert!(result.error.is_none());
+        assert_eq!(result.duration_ms, 100);
+    }
+
+    #[test]
+    fn test_step_result_failure() {
+        let result = StepResult::failure("step1", "something went wrong", 50);
+
+        assert!(!result.success);
+        assert_eq!(result.step_name, "step1");
+        assert!(result.output.is_none());
+        assert_eq!(result.error, Some("something went wrong".to_string()));
+    }
+
+    #[test]
+    fn test_step_result_with_retry_attempts() {
+        let result = StepResult::success("step1", None, 100).with_retry_attempts(3);
+
+        assert_eq!(result.retry_attempts, 3);
+    }
+
+    #[test]
+    fn test_execution_context_new() {
+        let context = ExecutionContext::new();
+
+        assert!(context.inputs().is_empty());
+        assert!(context.outputs().is_empty());
+        assert!(context.metadata().is_empty());
+    }
+
+    #[test]
+    fn test_execution_context_with_inputs() {
+        let context = ExecutionContext::new()
+            .with_input("query", serde_json::json!("test"))
+            .with_input("limit", serde_json::json!(10));
+
+        assert_eq!(context.inputs().len(), 2);
+        assert_eq!(context.get_input("query"), Some(&serde_json::json!("test")));
+        assert_eq!(context.get_input("limit"), Some(&serde_json::json!(10)));
+    }
+
+    #[test]
+    fn test_execution_context_from_inputs() {
+        let mut inputs = HashMap::new();
+        inputs.insert("key".to_string(), serde_json::json!("value"));
+
+        let context = ExecutionContext::from_inputs(inputs);
+
+        assert_eq!(context.inputs().len(), 1);
+        assert_eq!(context.get_input("key"), Some(&serde_json::json!("value")));
+    }
+
+    #[test]
+    fn test_execution_context_outputs() {
+        let mut context = ExecutionContext::new();
+
+        context.set_output("step1", serde_json::json!({"result": 42}));
+
+        assert_eq!(
+            context.get_output("step1"),
+            Some(&serde_json::json!({"result": 42}))
+        );
+    }
+
+    #[test]
+    fn test_execution_context_variables() {
+        let mut context = ExecutionContext::new()
+            .with_input("input1", serde_json::json!("in"))
+            .with_input("shared", serde_json::json!("from_input"));
+
+        context.set_output("step1", serde_json::json!("out"));
+        context.set_output("shared", serde_json::json!("from_output"));
+
+        let vars = context.variables();
+
+        // Should have all keys
+        assert_eq!(vars.len(), 3);
+        // Outputs override inputs for shared keys
+        assert_eq!(vars.get("shared"), Some(&serde_json::json!("from_output")));
+    }
+
+    #[test]
+    fn test_execution_context_metadata() {
+        let context = ExecutionContext::new()
+            .with_metadata("trace_id", serde_json::json!("abc123"))
+            .with_metadata("user_id", serde_json::json!(42));
+
+        assert_eq!(context.metadata().len(), 2);
+        assert_eq!(
+            context.get_metadata("trace_id"),
+            Some(&serde_json::json!("abc123"))
+        );
+    }
+
+    #[test]
+    fn test_execution_context_clear_outputs() {
+        let mut context = ExecutionContext::new();
+        context.set_output("step1", serde_json::json!("result"));
+
+        assert_eq!(context.outputs().len(), 1);
+
+        context.clear_outputs();
+
+        assert!(context.outputs().is_empty());
+    }
+
+    #[test]
+    fn test_execution_context_with_config() {
+        use crate::TimeoutConfig;
+        use std::time::Duration;
+
+        let config = ExecutionConfig::new()
+            .with_timeout(TimeoutConfig::new().with_step_timeout(Duration::from_secs(60)));
+
+        let context = ExecutionContext::new().with_config(config);
+
+        assert_eq!(
+            context.config().timeout.step_timeout,
+            Duration::from_secs(60)
+        );
+    }
+}

--- a/crates/thulp-skills/src/hooks.rs
+++ b/crates/thulp-skills/src/hooks.rs
@@ -1,0 +1,450 @@
+//! Execution lifecycle hooks.
+//!
+//! This module provides the [`ExecutionHooks`] trait for observing and reacting
+//! to skill execution lifecycle events.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use thulp_skills::{ExecutionHooks, Skill, SkillStep, SkillResult, StepResult, ExecutionContext};
+//!
+//! struct LoggingHooks;
+//!
+//! impl ExecutionHooks for LoggingHooks {
+//!     fn before_skill(&self, skill: &Skill, context: &ExecutionContext) {
+//!         println!("Starting skill: {}", skill.name);
+//!     }
+//!
+//!     fn after_skill(&self, skill: &Skill, result: &SkillResult, context: &ExecutionContext) {
+//!         println!("Completed skill: {} (success={})", skill.name, result.success);
+//!     }
+//! }
+//! ```
+
+use crate::{ExecutionContext, Skill, SkillError, SkillResult, SkillStep, StepResult};
+
+/// Lifecycle hooks for skill execution.
+///
+/// Implement this trait to observe and react to execution lifecycle events.
+/// All methods have default no-op implementations, so you only need to
+/// implement the ones you care about.
+///
+/// # Thread Safety
+///
+/// Implementations must be `Send + Sync` to allow use with async executors.
+///
+/// # Example
+///
+/// ```ignore
+/// use thulp_skills::{ExecutionHooks, Skill, ExecutionContext, SkillResult};
+///
+/// struct MetricsHooks {
+///     // metrics collector
+/// }
+///
+/// impl ExecutionHooks for MetricsHooks {
+///     fn before_skill(&self, skill: &Skill, _context: &ExecutionContext) {
+///         // Record skill execution start
+///     }
+///
+///     fn after_skill(&self, skill: &Skill, result: &SkillResult, _context: &ExecutionContext) {
+///         // Record skill execution end, success/failure
+///     }
+/// }
+/// ```
+pub trait ExecutionHooks: Send + Sync {
+    /// Called before a skill begins execution.
+    ///
+    /// # Arguments
+    ///
+    /// * `skill` - The skill about to be executed
+    /// * `context` - The execution context with inputs
+    fn before_skill(&self, _skill: &Skill, _context: &ExecutionContext) {}
+
+    /// Called after a skill completes execution (success or failure).
+    ///
+    /// # Arguments
+    ///
+    /// * `skill` - The skill that was executed
+    /// * `result` - The result of the skill execution
+    /// * `context` - The execution context with outputs
+    fn after_skill(&self, _skill: &Skill, _result: &SkillResult, _context: &ExecutionContext) {}
+
+    /// Called before a step begins execution.
+    ///
+    /// # Arguments
+    ///
+    /// * `step` - The step about to be executed
+    /// * `step_index` - Zero-based index of the step in the skill
+    /// * `context` - The current execution context
+    fn before_step(&self, _step: &SkillStep, _step_index: usize, _context: &ExecutionContext) {}
+
+    /// Called after a step completes execution (success or failure).
+    ///
+    /// # Arguments
+    ///
+    /// * `step` - The step that was executed
+    /// * `step_index` - Zero-based index of the step in the skill
+    /// * `result` - The result of the step execution
+    /// * `context` - The current execution context
+    fn after_step(
+        &self,
+        _step: &SkillStep,
+        _step_index: usize,
+        _result: &StepResult,
+        _context: &ExecutionContext,
+    ) {
+    }
+
+    /// Called when a step is about to be retried.
+    ///
+    /// # Arguments
+    ///
+    /// * `step` - The step being retried
+    /// * `attempt` - The attempt number (1-based, so first retry is attempt 2)
+    /// * `error` - The error that caused the retry
+    /// * `context` - The current execution context
+    fn on_retry(
+        &self,
+        _step: &SkillStep,
+        _attempt: usize,
+        _error: &str,
+        _context: &ExecutionContext,
+    ) {
+    }
+
+    /// Called when an error occurs during execution.
+    ///
+    /// This is called for errors that are not retried, or after all retries
+    /// are exhausted.
+    ///
+    /// # Arguments
+    ///
+    /// * `error` - The error that occurred
+    /// * `context` - The current execution context
+    fn on_error(&self, _error: &SkillError, _context: &ExecutionContext) {}
+
+    /// Called when a step times out.
+    ///
+    /// # Arguments
+    ///
+    /// * `step` - The step that timed out
+    /// * `duration_ms` - How long the step ran before timing out
+    /// * `context` - The current execution context
+    fn on_timeout(&self, _step: &SkillStep, _duration_ms: u64, _context: &ExecutionContext) {}
+}
+
+/// A no-op implementation of [`ExecutionHooks`].
+///
+/// This is the default hooks implementation that does nothing for all
+/// lifecycle events. Use this when you don't need any hooks.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoOpHooks;
+
+impl NoOpHooks {
+    /// Create a new no-op hooks instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ExecutionHooks for NoOpHooks {}
+
+/// A hooks implementation that logs execution events using tracing.
+///
+/// This provides observability into skill execution without requiring
+/// custom hook implementations.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TracingHooks {
+    /// Log level for debug messages
+    include_debug: bool,
+}
+
+impl TracingHooks {
+    /// Create a new tracing hooks instance.
+    pub fn new() -> Self {
+        Self {
+            include_debug: false,
+        }
+    }
+
+    /// Include debug-level messages.
+    pub fn with_debug(mut self) -> Self {
+        self.include_debug = true;
+        self
+    }
+}
+
+impl ExecutionHooks for TracingHooks {
+    fn before_skill(&self, skill: &Skill, context: &ExecutionContext) {
+        tracing::info!(
+            skill_name = %skill.name,
+            input_count = context.inputs().len(),
+            step_count = skill.steps.len(),
+            "Starting skill execution"
+        );
+
+        if self.include_debug {
+            tracing::debug!(
+                skill_name = %skill.name,
+                inputs = ?context.inputs().keys().collect::<Vec<_>>(),
+                "Skill inputs"
+            );
+        }
+    }
+
+    fn after_skill(&self, skill: &Skill, result: &SkillResult, context: &ExecutionContext) {
+        if result.success {
+            tracing::info!(
+                skill_name = %skill.name,
+                steps_completed = result.step_results.len(),
+                output_count = context.outputs().len(),
+                "Skill execution completed successfully"
+            );
+        } else {
+            tracing::warn!(
+                skill_name = %skill.name,
+                steps_completed = result.step_results.len(),
+                error = ?result.error,
+                "Skill execution failed"
+            );
+        }
+    }
+
+    fn before_step(&self, step: &SkillStep, step_index: usize, _context: &ExecutionContext) {
+        tracing::info!(
+            step_name = %step.name,
+            step_index = step_index,
+            tool = %step.tool,
+            "Starting step execution"
+        );
+    }
+
+    fn after_step(
+        &self,
+        step: &SkillStep,
+        step_index: usize,
+        result: &StepResult,
+        _context: &ExecutionContext,
+    ) {
+        if result.success {
+            tracing::info!(
+                step_name = %step.name,
+                step_index = step_index,
+                duration_ms = result.duration_ms,
+                retry_attempts = result.retry_attempts,
+                "Step completed successfully"
+            );
+        } else {
+            tracing::warn!(
+                step_name = %step.name,
+                step_index = step_index,
+                duration_ms = result.duration_ms,
+                error = ?result.error,
+                "Step failed"
+            );
+        }
+    }
+
+    fn on_retry(&self, step: &SkillStep, attempt: usize, error: &str, _context: &ExecutionContext) {
+        tracing::warn!(
+            step_name = %step.name,
+            attempt = attempt,
+            error = %error,
+            "Retrying step after failure"
+        );
+    }
+
+    fn on_error(&self, error: &SkillError, _context: &ExecutionContext) {
+        tracing::error!(
+            error = %error,
+            "Skill execution error"
+        );
+    }
+
+    fn on_timeout(&self, step: &SkillStep, duration_ms: u64, _context: &ExecutionContext) {
+        tracing::warn!(
+            step_name = %step.name,
+            duration_ms = duration_ms,
+            "Step timed out"
+        );
+    }
+}
+
+/// Compose multiple hooks implementations.
+///
+/// This allows combining multiple hooks (e.g., logging + metrics) into a single
+/// hooks instance that calls all of them.
+pub struct CompositeHooks {
+    hooks: Vec<Box<dyn ExecutionHooks>>,
+}
+
+impl CompositeHooks {
+    /// Create a new composite hooks instance.
+    pub fn new() -> Self {
+        Self { hooks: Vec::new() }
+    }
+
+    /// Add a hooks implementation.
+    pub fn with<H: ExecutionHooks + 'static>(mut self, hooks: H) -> Self {
+        self.hooks.push(Box::new(hooks));
+        self
+    }
+}
+
+impl Default for CompositeHooks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExecutionHooks for CompositeHooks {
+    fn before_skill(&self, skill: &Skill, context: &ExecutionContext) {
+        for h in &self.hooks {
+            h.before_skill(skill, context);
+        }
+    }
+
+    fn after_skill(&self, skill: &Skill, result: &SkillResult, context: &ExecutionContext) {
+        for h in &self.hooks {
+            h.after_skill(skill, result, context);
+        }
+    }
+
+    fn before_step(&self, step: &SkillStep, step_index: usize, context: &ExecutionContext) {
+        for h in &self.hooks {
+            h.before_step(step, step_index, context);
+        }
+    }
+
+    fn after_step(
+        &self,
+        step: &SkillStep,
+        step_index: usize,
+        result: &StepResult,
+        context: &ExecutionContext,
+    ) {
+        for h in &self.hooks {
+            h.after_step(step, step_index, result, context);
+        }
+    }
+
+    fn on_retry(&self, step: &SkillStep, attempt: usize, error: &str, context: &ExecutionContext) {
+        for h in &self.hooks {
+            h.on_retry(step, attempt, error, context);
+        }
+    }
+
+    fn on_error(&self, error: &SkillError, context: &ExecutionContext) {
+        for h in &self.hooks {
+            h.on_error(error, context);
+        }
+    }
+
+    fn on_timeout(&self, step: &SkillStep, duration_ms: u64, context: &ExecutionContext) {
+        for h in &self.hooks {
+            h.on_timeout(step, duration_ms, context);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_no_op_hooks() {
+        let hooks = NoOpHooks::new();
+        let skill = Skill::new("test", "Test skill");
+        let context = ExecutionContext::new();
+
+        // All methods should be callable without panic
+        hooks.before_skill(&skill, &context);
+        hooks.after_skill(
+            &skill,
+            &SkillResult {
+                success: true,
+                step_results: vec![],
+                output: None,
+                error: None,
+            },
+            &context,
+        );
+    }
+
+    #[test]
+    fn test_tracing_hooks_creation() {
+        let hooks = TracingHooks::new();
+        assert!(!hooks.include_debug);
+
+        let hooks_with_debug = TracingHooks::new().with_debug();
+        assert!(hooks_with_debug.include_debug);
+    }
+
+    #[test]
+    fn test_composite_hooks() {
+        struct CountingHooks {
+            before_count: Arc<AtomicUsize>,
+            after_count: Arc<AtomicUsize>,
+        }
+
+        impl ExecutionHooks for CountingHooks {
+            fn before_skill(&self, _skill: &Skill, _context: &ExecutionContext) {
+                self.before_count.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn after_skill(
+                &self,
+                _skill: &Skill,
+                _result: &SkillResult,
+                _context: &ExecutionContext,
+            ) {
+                self.after_count.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let before_count1 = Arc::new(AtomicUsize::new(0));
+        let after_count1 = Arc::new(AtomicUsize::new(0));
+        let before_count2 = Arc::new(AtomicUsize::new(0));
+        let after_count2 = Arc::new(AtomicUsize::new(0));
+
+        let hooks = CompositeHooks::new()
+            .with(CountingHooks {
+                before_count: before_count1.clone(),
+                after_count: after_count1.clone(),
+            })
+            .with(CountingHooks {
+                before_count: before_count2.clone(),
+                after_count: after_count2.clone(),
+            });
+
+        let skill = Skill::new("test", "Test skill");
+        let context = ExecutionContext::new();
+        let result = SkillResult {
+            success: true,
+            step_results: vec![],
+            output: None,
+            error: None,
+        };
+
+        hooks.before_skill(&skill, &context);
+        hooks.after_skill(&skill, &result, &context);
+
+        assert_eq!(before_count1.load(Ordering::SeqCst), 1);
+        assert_eq!(after_count1.load(Ordering::SeqCst), 1);
+        assert_eq!(before_count2.load(Ordering::SeqCst), 1);
+        assert_eq!(after_count2.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_composite_hooks_default() {
+        let hooks = CompositeHooks::default();
+        let skill = Skill::new("test", "Test skill");
+        let context = ExecutionContext::new();
+
+        // Should not panic with empty hooks list
+        hooks.before_skill(&skill, &context);
+    }
+}

--- a/crates/thulp-skills/src/retry.rs
+++ b/crates/thulp-skills/src/retry.rs
@@ -1,0 +1,415 @@
+//! Retry utilities for skill execution.
+//!
+//! This module provides retry logic with configurable backoff strategies.
+
+use crate::config::{BackoffStrategy, RetryConfig, RetryableError};
+use std::future::Future;
+use std::time::Duration;
+
+/// Errors that can occur during retried execution.
+#[derive(Debug, thiserror::Error)]
+pub enum RetryError<E> {
+    /// All retry attempts were exhausted.
+    #[error("exhausted {attempts} retry attempts: {last_error}")]
+    Exhausted {
+        /// Number of attempts made.
+        attempts: usize,
+        /// The last error that occurred.
+        #[source]
+        last_error: E,
+    },
+
+    /// The error was not retryable.
+    #[error("non-retryable error: {0}")]
+    NotRetryable(#[source] E),
+}
+
+impl<E> RetryError<E> {
+    /// Check if retries were exhausted.
+    pub fn is_exhausted(&self) -> bool {
+        matches!(self, RetryError::Exhausted { .. })
+    }
+
+    /// Get the number of attempts made if exhausted.
+    pub fn attempts(&self) -> Option<usize> {
+        match self {
+            RetryError::Exhausted { attempts, .. } => Some(*attempts),
+            _ => None,
+        }
+    }
+
+    /// Get the underlying error.
+    pub fn into_inner(self) -> E {
+        match self {
+            RetryError::Exhausted { last_error, .. } => last_error,
+            RetryError::NotRetryable(e) => e,
+        }
+    }
+}
+
+/// Execute an operation with retries.
+///
+/// # Arguments
+///
+/// * `config` - Retry configuration.
+/// * `operation_name` - Name of the operation for logging.
+/// * `is_retryable` - Function to determine if an error is retryable.
+/// * `operation` - The async operation to execute.
+///
+/// # Returns
+///
+/// Returns `Ok(T)` if the operation succeeds within the retry limit,
+/// or `Err(RetryError)` if all retries are exhausted or the error is not retryable.
+///
+/// # Examples
+///
+/// ```ignore
+/// use thulp_skills::retry::with_retry;
+/// use thulp_skills::config::RetryConfig;
+///
+/// async fn example() {
+///     let result = with_retry(
+///         &RetryConfig::default(),
+///         "fetch data",
+///         |e: &std::io::Error| e.kind() == std::io::ErrorKind::TimedOut,
+///         || async { Ok::<_, std::io::Error>("data") }
+///     ).await;
+/// }
+/// ```
+pub async fn with_retry<F, Fut, T, E, R>(
+    config: &RetryConfig,
+    operation_name: &str,
+    is_retryable: R,
+    mut operation: F,
+) -> Result<T, RetryError<E>>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    R: Fn(&E) -> bool,
+    E: std::fmt::Display,
+{
+    let mut attempt = 0;
+
+    loop {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                attempt += 1;
+
+                // Check if we should retry
+                if attempt > config.max_retries {
+                    return Err(RetryError::Exhausted {
+                        attempts: attempt,
+                        last_error: e,
+                    });
+                }
+
+                if !is_retryable(&e) {
+                    return Err(RetryError::NotRetryable(e));
+                }
+
+                let delay = calculate_delay(config, attempt);
+                tracing::warn!(
+                    attempt = attempt,
+                    max_retries = config.max_retries,
+                    operation = operation_name,
+                    delay_ms = delay.as_millis() as u64,
+                    error = %e,
+                    "Retrying operation after error"
+                );
+
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+/// Execute an operation with retries using standard retryable error detection.
+///
+/// This is a convenience wrapper around `with_retry` that uses the
+/// `RetryConfig::retryable_errors` to determine if an error is retryable.
+pub async fn with_retry_default<F, Fut, T, E>(
+    config: &RetryConfig,
+    operation_name: &str,
+    operation: F,
+) -> Result<T, RetryError<E>>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Display + AsRef<dyn std::error::Error + 'static>,
+{
+    with_retry(config, operation_name, |e| is_error_retryable(e, config), operation).await
+}
+
+/// Calculate the delay before the next retry attempt.
+pub fn calculate_delay(config: &RetryConfig, attempt: usize) -> Duration {
+    let base_delay = match config.backoff {
+        BackoffStrategy::Fixed => config.initial_delay,
+        BackoffStrategy::Exponential => {
+            let multiplier = 2u32.saturating_pow(attempt.saturating_sub(1) as u32);
+            config.initial_delay.saturating_mul(multiplier)
+        }
+        BackoffStrategy::ExponentialJitter => {
+            let multiplier = 2u32.saturating_pow(attempt.saturating_sub(1) as u32);
+            let base = config.initial_delay.saturating_mul(multiplier);
+            let jitter_range = base.as_millis() as u64 / 2;
+            let jitter = if jitter_range > 0 {
+                fastrand::u64(0..jitter_range)
+            } else {
+                0
+            };
+            base + Duration::from_millis(jitter)
+        }
+    };
+
+    std::cmp::min(base_delay, config.max_delay)
+}
+
+/// Check if an error is retryable based on the configuration.
+pub fn is_error_retryable<E>(error: &E, config: &RetryConfig) -> bool
+where
+    E: std::fmt::Display,
+{
+    if config.retryable_errors.contains(&RetryableError::All) {
+        return true;
+    }
+
+    let msg = error.to_string().to_lowercase();
+
+    // Check for rate limit errors
+    if config.retryable_errors.contains(&RetryableError::RateLimit)
+        && (msg.contains("rate limit") || msg.contains("429") || msg.contains("too many requests"))
+    {
+        return true;
+    }
+
+    // Check for timeout errors
+    if config.retryable_errors.contains(&RetryableError::Timeout)
+        && (msg.contains("timeout") || msg.contains("timed out"))
+    {
+        return true;
+    }
+
+    // Check for server errors
+    if config.retryable_errors.contains(&RetryableError::ServerError)
+        && (msg.contains("500")
+            || msg.contains("502")
+            || msg.contains("503")
+            || msg.contains("504")
+            || msg.contains("internal server error")
+            || msg.contains("bad gateway")
+            || msg.contains("service unavailable"))
+    {
+        return true;
+    }
+
+    // Check for network errors
+    if config.retryable_errors.contains(&RetryableError::Network)
+        && (msg.contains("connection")
+            || msg.contains("network")
+            || msg.contains("dns")
+            || msg.contains("resolve")
+            || msg.contains("unreachable"))
+    {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_calculate_delay_fixed() {
+        let config = RetryConfig {
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(10),
+            backoff: BackoffStrategy::Fixed,
+            ..Default::default()
+        };
+
+        assert_eq!(calculate_delay(&config, 1), Duration::from_millis(100));
+        assert_eq!(calculate_delay(&config, 2), Duration::from_millis(100));
+        assert_eq!(calculate_delay(&config, 5), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_calculate_delay_exponential() {
+        let config = RetryConfig {
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(10),
+            backoff: BackoffStrategy::Exponential,
+            ..Default::default()
+        };
+
+        assert_eq!(calculate_delay(&config, 1), Duration::from_millis(100));
+        assert_eq!(calculate_delay(&config, 2), Duration::from_millis(200));
+        assert_eq!(calculate_delay(&config, 3), Duration::from_millis(400));
+        assert_eq!(calculate_delay(&config, 4), Duration::from_millis(800));
+    }
+
+    #[test]
+    fn test_calculate_delay_max_cap() {
+        let config = RetryConfig {
+            initial_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(5),
+            backoff: BackoffStrategy::Exponential,
+            ..Default::default()
+        };
+
+        // Would be 8 seconds without cap
+        assert_eq!(calculate_delay(&config, 4), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn test_is_error_retryable_rate_limit() {
+        let config = RetryConfig::default();
+
+        assert!(is_error_retryable(&"Rate limit exceeded", &config));
+        assert!(is_error_retryable(&"HTTP 429 Too Many Requests", &config));
+    }
+
+    #[test]
+    fn test_is_error_retryable_timeout() {
+        let config = RetryConfig::default();
+
+        assert!(is_error_retryable(&"Connection timed out", &config));
+        assert!(is_error_retryable(&"Request timeout", &config));
+    }
+
+    #[test]
+    fn test_is_error_retryable_network() {
+        let config = RetryConfig::default();
+
+        assert!(is_error_retryable(&"Connection refused", &config));
+        assert!(is_error_retryable(&"Network unreachable", &config));
+        assert!(is_error_retryable(&"DNS resolution failed", &config));
+    }
+
+    #[test]
+    fn test_is_error_retryable_not_configured() {
+        let config = RetryConfig {
+            retryable_errors: vec![RetryableError::Timeout],
+            ..Default::default()
+        };
+
+        assert!(!is_error_retryable(&"Rate limit exceeded", &config));
+        assert!(is_error_retryable(&"Request timed out", &config));
+    }
+
+    #[test]
+    fn test_is_error_retryable_all() {
+        let config = RetryConfig::new().retry_all_errors();
+
+        assert!(is_error_retryable(&"Any error at all", &config));
+        assert!(is_error_retryable(&"Random failure", &config));
+    }
+
+    #[tokio::test]
+    async fn test_retry_success_first_try() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = Arc::clone(&attempts);
+
+        let result = with_retry(
+            &RetryConfig::default(),
+            "test",
+            |_: &String| true,
+            || {
+                let attempts = Arc::clone(&attempts_clone);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, String>("success")
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "success");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_retry_success_after_failures() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = Arc::clone(&attempts);
+
+        let config = RetryConfig {
+            max_retries: 3,
+            initial_delay: Duration::from_millis(10),
+            ..Default::default()
+        };
+
+        let result = with_retry(&config, "test", |_: &String| true, || {
+            let attempts = Arc::clone(&attempts_clone);
+            async move {
+                let n = attempts.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err("transient error".to_string())
+                } else {
+                    Ok("success")
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "success");
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_retry_exhausted() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = Arc::clone(&attempts);
+
+        let config = RetryConfig {
+            max_retries: 2,
+            initial_delay: Duration::from_millis(10),
+            ..Default::default()
+        };
+
+        let result: Result<(), RetryError<String>> =
+            with_retry(&config, "test", |_: &String| true, || {
+                let attempts = Arc::clone(&attempts_clone);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err("persistent error".to_string())
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is_exhausted());
+        assert_eq!(err.attempts(), Some(3)); // 1 initial + 2 retries = 3 attempts
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_retry_not_retryable() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = Arc::clone(&attempts);
+
+        let config = RetryConfig::default();
+
+        let result: Result<(), RetryError<String>> =
+            with_retry(&config, "test", |_: &String| false, || {
+                let attempts = Arc::clone(&attempts_clone);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err("non-retryable error".to_string())
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(!err.is_exhausted());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/thulp-skills/src/timeout.rs
+++ b/crates/thulp-skills/src/timeout.rs
@@ -111,12 +111,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_success() {
-        let result: Result<&str, TimeoutError<io::Error>> = with_timeout(
-            Duration::from_secs(1),
-            "test operation",
-            async { Ok("success") },
-        )
-        .await;
+        let result: Result<&str, TimeoutError<io::Error>> =
+            with_timeout(Duration::from_secs(1), "test operation", async {
+                Ok("success")
+            })
+            .await;
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "success");
@@ -124,15 +123,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_fires() {
-        let result: Result<(), TimeoutError<io::Error>> = with_timeout(
-            Duration::from_millis(50),
-            "slow operation",
-            async {
+        let result: Result<(), TimeoutError<io::Error>> =
+            with_timeout(Duration::from_millis(50), "slow operation", async {
                 tokio::time::sleep(Duration::from_secs(10)).await;
                 Ok(())
-            },
-        )
-        .await;
+            })
+            .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -143,12 +139,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_execution_error() {
-        let result: Result<(), TimeoutError<io::Error>> = with_timeout(
-            Duration::from_secs(1),
-            "failing operation",
-            async { Err(io::Error::new(io::ErrorKind::NotFound, "not found")) },
-        )
-        .await;
+        let result: Result<(), TimeoutError<io::Error>> =
+            with_timeout(Duration::from_secs(1), "failing operation", async {
+                Err(io::Error::new(io::ErrorKind::NotFound, "not found"))
+            })
+            .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();

--- a/crates/thulp-skills/src/timeout.rs
+++ b/crates/thulp-skills/src/timeout.rs
@@ -1,0 +1,176 @@
+//! Timeout utilities for skill execution.
+//!
+//! This module provides timeout wrappers for async operations.
+
+use std::future::Future;
+use std::time::Duration;
+
+/// Errors that can occur during timeout-wrapped execution.
+#[derive(Debug, thiserror::Error)]
+pub enum TimeoutError<E> {
+    /// The operation timed out.
+    #[error("operation timed out after {duration:?}: {context}")]
+    Timeout {
+        /// Duration that elapsed before timeout.
+        duration: Duration,
+        /// Context describing what timed out.
+        context: String,
+    },
+
+    /// The operation completed but returned an error.
+    #[error("execution error: {0}")]
+    ExecutionError(#[source] E),
+}
+
+impl<E> TimeoutError<E> {
+    /// Check if this is a timeout error.
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, TimeoutError::Timeout { .. })
+    }
+
+    /// Check if this is an execution error.
+    pub fn is_execution_error(&self) -> bool {
+        matches!(self, TimeoutError::ExecutionError(_))
+    }
+
+    /// Get the duration if this is a timeout error.
+    pub fn timeout_duration(&self) -> Option<Duration> {
+        match self {
+            TimeoutError::Timeout { duration, .. } => Some(*duration),
+            _ => None,
+        }
+    }
+}
+
+/// Execute a future with a timeout.
+///
+/// # Arguments
+///
+/// * `duration` - Maximum time to wait for the future to complete.
+/// * `context` - Description of the operation for error messages.
+/// * `future` - The async operation to execute.
+///
+/// # Returns
+///
+/// Returns `Ok(T)` if the future completes within the timeout,
+/// `Err(TimeoutError::Timeout)` if the timeout expires, or
+/// `Err(TimeoutError::ExecutionError)` if the future returns an error.
+///
+/// # Examples
+///
+/// ```ignore
+/// use std::time::Duration;
+/// use thulp_skills::timeout::with_timeout;
+///
+/// async fn example() {
+///     let result = with_timeout(
+///         Duration::from_secs(5),
+///         "fetch data",
+///         async { Ok::<_, std::io::Error>("data") }
+///     ).await;
+///     
+///     assert!(result.is_ok());
+/// }
+/// ```
+pub async fn with_timeout<F, T, E>(
+    duration: Duration,
+    context: impl Into<String>,
+    future: F,
+) -> Result<T, TimeoutError<E>>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    let context = context.into();
+
+    match tokio::time::timeout(duration, future).await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(e)) => Err(TimeoutError::ExecutionError(e)),
+        Err(_elapsed) => Err(TimeoutError::Timeout { duration, context }),
+    }
+}
+
+/// Execute an infallible future with a timeout.
+///
+/// Similar to `with_timeout` but for futures that don't return a Result.
+///
+/// # Returns
+///
+/// Returns `Some(T)` if the future completes within the timeout,
+/// or `None` if the timeout expires.
+pub async fn with_timeout_infallible<F, T>(duration: Duration, future: F) -> Option<T>
+where
+    F: Future<Output = T>,
+{
+    tokio::time::timeout(duration, future).await.ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[tokio::test]
+    async fn test_timeout_success() {
+        let result: Result<&str, TimeoutError<io::Error>> = with_timeout(
+            Duration::from_secs(1),
+            "test operation",
+            async { Ok("success") },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "success");
+    }
+
+    #[tokio::test]
+    async fn test_timeout_fires() {
+        let result: Result<(), TimeoutError<io::Error>> = with_timeout(
+            Duration::from_millis(50),
+            "slow operation",
+            async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                Ok(())
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is_timeout());
+        assert!(err.timeout_duration().is_some());
+        assert!(err.to_string().contains("slow operation"));
+    }
+
+    #[tokio::test]
+    async fn test_timeout_execution_error() {
+        let result: Result<(), TimeoutError<io::Error>> = with_timeout(
+            Duration::from_secs(1),
+            "failing operation",
+            async { Err(io::Error::new(io::ErrorKind::NotFound, "not found")) },
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is_execution_error());
+        assert!(err.timeout_duration().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_timeout_infallible_success() {
+        let result = with_timeout_infallible(Duration::from_secs(1), async { 42 }).await;
+
+        assert_eq!(result, Some(42));
+    }
+
+    #[tokio::test]
+    async fn test_timeout_infallible_timeout() {
+        let result = with_timeout_infallible(Duration::from_millis(50), async {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            42
+        })
+        .await;
+
+        assert_eq!(result, None);
+    }
+}

--- a/crates/thulp-workspace/Cargo.toml
+++ b/crates/thulp-workspace/Cargo.toml
@@ -21,3 +21,5 @@ serde_yaml = "0.9"
 thiserror = "2.0"
 serde_json = "1.0"
 tempfile = "3.24"
+uuid = { version = "1.0", features = ["v4", "serde"] }
+tracing = "0.1"

--- a/crates/thulp-workspace/src/filter.rs
+++ b/crates/thulp-workspace/src/filter.rs
@@ -1,0 +1,354 @@
+//! Session filtering for queries.
+//!
+//! This module provides the `SessionFilter` enum for filtering sessions
+//! when listing or querying.
+
+use crate::session::{Session, SessionStatus, SessionType, Timestamp};
+
+/// Filter for querying sessions.
+///
+/// Filters can be combined using `SessionFilter::And` for complex queries.
+///
+/// # Example
+///
+/// ```ignore
+/// use thulp_workspace::{SessionFilter, SessionStatus};
+///
+/// // Find active conversation sessions
+/// let filter = SessionFilter::And(vec![
+///     SessionFilter::ByStatus(SessionStatus::Active),
+///     SessionFilter::ByTypeName("conversation".to_string()),
+/// ]);
+/// ```
+#[derive(Debug, Clone)]
+pub enum SessionFilter {
+    /// Match sessions with the given status.
+    ByStatus(SessionStatus),
+
+    /// Match sessions by type name (e.g., "conversation", "teacher_demo").
+    ByTypeName(String),
+
+    /// Match sessions that have a specific tag.
+    HasTag(String),
+
+    /// Match sessions created after the given timestamp.
+    CreatedAfter(Timestamp),
+
+    /// Match sessions created before the given timestamp.
+    CreatedBefore(Timestamp),
+
+    /// Match sessions updated after the given timestamp.
+    UpdatedAfter(Timestamp),
+
+    /// Match sessions updated before the given timestamp.
+    UpdatedBefore(Timestamp),
+
+    /// Match sessions where the name contains the given text.
+    NameContains(String),
+
+    /// Match sessions that have a parent session.
+    HasParent,
+
+    /// Match sessions with a specific parent session ID.
+    WithParent(crate::session::SessionId),
+
+    /// Match sessions that are root sessions (no parent).
+    IsRoot,
+
+    /// Combine multiple filters with AND logic.
+    And(Vec<SessionFilter>),
+
+    /// Combine multiple filters with OR logic.
+    Or(Vec<SessionFilter>),
+
+    /// Negate a filter.
+    Not(Box<SessionFilter>),
+
+    /// Match all sessions.
+    All,
+}
+
+impl SessionFilter {
+    /// Check if a session matches this filter.
+    pub fn matches(&self, session: &Session) -> bool {
+        match self {
+            SessionFilter::ByStatus(status) => session.status() == *status,
+
+            SessionFilter::ByTypeName(type_name) => {
+                let session_type_name = session_type_name(&session.metadata.session_type);
+                session_type_name.eq_ignore_ascii_case(type_name)
+            }
+
+            SessionFilter::HasTag(tag) => session.metadata.tags.iter().any(|t| t == tag),
+
+            SessionFilter::CreatedAfter(timestamp) => {
+                session.metadata.created_at.as_millis() > timestamp.as_millis()
+            }
+
+            SessionFilter::CreatedBefore(timestamp) => {
+                session.metadata.created_at.as_millis() < timestamp.as_millis()
+            }
+
+            SessionFilter::UpdatedAfter(timestamp) => {
+                session.metadata.updated_at.as_millis() > timestamp.as_millis()
+            }
+
+            SessionFilter::UpdatedBefore(timestamp) => {
+                session.metadata.updated_at.as_millis() < timestamp.as_millis()
+            }
+
+            SessionFilter::NameContains(text) => session
+                .metadata
+                .name
+                .to_lowercase()
+                .contains(&text.to_lowercase()),
+
+            SessionFilter::HasParent => session.metadata.parent_session.is_some(),
+
+            SessionFilter::WithParent(parent_id) => {
+                session.metadata.parent_session.as_ref() == Some(parent_id)
+            }
+
+            SessionFilter::IsRoot => session.metadata.parent_session.is_none(),
+
+            SessionFilter::And(filters) => filters.iter().all(|f| f.matches(session)),
+
+            SessionFilter::Or(filters) => filters.iter().any(|f| f.matches(session)),
+
+            SessionFilter::Not(filter) => !filter.matches(session),
+
+            SessionFilter::All => true,
+        }
+    }
+
+    /// Create an AND filter from two filters.
+    pub fn and(self, other: SessionFilter) -> SessionFilter {
+        match self {
+            SessionFilter::And(mut filters) => {
+                filters.push(other);
+                SessionFilter::And(filters)
+            }
+            _ => SessionFilter::And(vec![self, other]),
+        }
+    }
+
+    /// Create an OR filter from two filters.
+    pub fn or(self, other: SessionFilter) -> SessionFilter {
+        match self {
+            SessionFilter::Or(mut filters) => {
+                filters.push(other);
+                SessionFilter::Or(filters)
+            }
+            _ => SessionFilter::Or(vec![self, other]),
+        }
+    }
+
+    /// Negate this filter.
+    pub fn negate(self) -> SessionFilter {
+        SessionFilter::Not(Box::new(self))
+    }
+
+    /// Create a filter for active sessions.
+    pub fn active() -> Self {
+        SessionFilter::ByStatus(SessionStatus::Active)
+    }
+
+    /// Create a filter for completed sessions.
+    pub fn completed() -> Self {
+        SessionFilter::ByStatus(SessionStatus::Completed)
+    }
+
+    /// Create a filter for failed sessions.
+    pub fn failed() -> Self {
+        SessionFilter::ByStatus(SessionStatus::Failed)
+    }
+
+    /// Create a filter for conversation sessions.
+    pub fn conversations() -> Self {
+        SessionFilter::ByTypeName("conversation".to_string())
+    }
+
+    /// Create a filter for teacher demo sessions.
+    pub fn teacher_demos() -> Self {
+        SessionFilter::ByTypeName("teacher_demo".to_string())
+    }
+
+    /// Create a filter for evaluation sessions.
+    pub fn evaluations() -> Self {
+        SessionFilter::ByTypeName("evaluation".to_string())
+    }
+
+    /// Create a filter for refinement sessions.
+    pub fn refinements() -> Self {
+        SessionFilter::ByTypeName("refinement".to_string())
+    }
+
+    /// Create a filter for agent sessions.
+    pub fn agent_sessions() -> Self {
+        SessionFilter::ByTypeName("agent".to_string())
+    }
+}
+
+/// Get the type name for a session type.
+fn session_type_name(session_type: &SessionType) -> &'static str {
+    match session_type {
+        SessionType::TeacherDemo { .. } => "teacher_demo",
+        SessionType::Evaluation { .. } => "evaluation",
+        SessionType::Refinement { .. } => "refinement",
+        SessionType::Conversation { .. } => "conversation",
+        SessionType::Agent { .. } => "agent",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{Session, SessionId, SessionType};
+
+    fn create_test_session(name: &str) -> Session {
+        Session::new(
+            name,
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        )
+    }
+
+    #[test]
+    fn test_filter_by_status() {
+        let mut session = create_test_session("Test");
+
+        let filter = SessionFilter::ByStatus(SessionStatus::Active);
+        assert!(filter.matches(&session));
+
+        session.complete();
+        assert!(!filter.matches(&session));
+
+        let completed_filter = SessionFilter::ByStatus(SessionStatus::Completed);
+        assert!(completed_filter.matches(&session));
+    }
+
+    #[test]
+    fn test_filter_by_type_name() {
+        let conversation = Session::new(
+            "Test",
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        );
+
+        let evaluation = Session::new(
+            "Test",
+            SessionType::Evaluation {
+                skill_name: "test".to_string(),
+                test_cases: 10,
+            },
+        );
+
+        let conv_filter = SessionFilter::ByTypeName("conversation".to_string());
+        assert!(conv_filter.matches(&conversation));
+        assert!(!conv_filter.matches(&evaluation));
+
+        let eval_filter = SessionFilter::ByTypeName("evaluation".to_string());
+        assert!(eval_filter.matches(&evaluation));
+        assert!(!eval_filter.matches(&conversation));
+    }
+
+    #[test]
+    fn test_filter_has_tag() {
+        let mut session = create_test_session("Test");
+        session.metadata.tags.push("important".to_string());
+
+        let filter = SessionFilter::HasTag("important".to_string());
+        assert!(filter.matches(&session));
+
+        let no_tag_filter = SessionFilter::HasTag("other".to_string());
+        assert!(!no_tag_filter.matches(&session));
+    }
+
+    #[test]
+    fn test_filter_name_contains() {
+        let session = create_test_session("My Test Session");
+
+        let filter = SessionFilter::NameContains("test".to_string());
+        assert!(filter.matches(&session));
+
+        let no_match = SessionFilter::NameContains("other".to_string());
+        assert!(!no_match.matches(&session));
+    }
+
+    #[test]
+    fn test_filter_and() {
+        let mut session = create_test_session("Test");
+        session.metadata.tags.push("important".to_string());
+
+        let filter = SessionFilter::active().and(SessionFilter::HasTag("important".to_string()));
+
+        assert!(filter.matches(&session));
+
+        session.complete();
+        assert!(!filter.matches(&session));
+    }
+
+    #[test]
+    fn test_filter_or() {
+        let mut session = create_test_session("Test");
+
+        let filter = SessionFilter::completed().or(SessionFilter::active());
+
+        assert!(filter.matches(&session)); // Active
+
+        session.complete();
+        assert!(filter.matches(&session)); // Completed
+
+        session.fail();
+        assert!(!filter.matches(&session)); // Failed - neither active nor completed
+    }
+
+    #[test]
+    fn test_filter_not() {
+        let session = create_test_session("Test");
+
+        let filter = SessionFilter::completed().negate();
+        assert!(filter.matches(&session)); // Not completed (active)
+
+        let mut completed = create_test_session("Test");
+        completed.complete();
+        assert!(!filter.matches(&completed)); // Is completed
+    }
+
+    #[test]
+    fn test_filter_parent() {
+        let mut session = create_test_session("Test");
+
+        let has_parent = SessionFilter::HasParent;
+        let is_root = SessionFilter::IsRoot;
+
+        assert!(!has_parent.matches(&session));
+        assert!(is_root.matches(&session));
+
+        session.metadata.parent_session = Some(SessionId::new());
+        assert!(has_parent.matches(&session));
+        assert!(!is_root.matches(&session));
+    }
+
+    #[test]
+    fn test_filter_all() {
+        let session = create_test_session("Test");
+        assert!(SessionFilter::All.matches(&session));
+    }
+
+    #[test]
+    fn test_convenience_constructors() {
+        let session = Session::new(
+            "Test",
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        );
+
+        assert!(SessionFilter::conversations().matches(&session));
+        assert!(!SessionFilter::evaluations().matches(&session));
+        assert!(SessionFilter::active().matches(&session));
+    }
+}

--- a/crates/thulp-workspace/src/lib.rs
+++ b/crates/thulp-workspace/src/lib.rs
@@ -4,6 +4,58 @@
 //!
 //! This crate provides functionality for managing agent workspaces,
 //! including context, state, and session persistence.
+//!
+//! ## Features
+//!
+//! - **Workspace Management**: Create, load, and manage workspaces with metadata and context
+//! - **Session Management**: Track conversation history, tool calls, and skill executions
+//! - **Turn Counting**: Monitor conversation turns with configurable limits
+//! - **Persistence**: File-based storage for sessions with in-memory caching
+//! - **Filtering**: Query sessions by status, type, tags, and timestamps
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use thulp_workspace::{Workspace, SessionManager, SessionType, SessionFilter};
+//! use std::path::PathBuf;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Create a workspace
+//!     let workspace = Workspace::new("my-workspace", "My Workspace", PathBuf::from("."));
+//!
+//!     // Create a session manager
+//!     let manager = SessionManager::new(&workspace).await?;
+//!
+//!     // Create a session
+//!     let session = manager.create_session("Chat Session", SessionType::Conversation {
+//!         purpose: "User assistance".to_string(),
+//!     }).await?;
+//!
+//!     // Add entries
+//!     manager.add_entry(
+//!         session.id(),
+//!         EntryType::UserMessage,
+//!         serde_json::json!({"text": "Hello!"}),
+//!     ).await?;
+//!
+//!     // Query sessions
+//!     let active_sessions = manager.find_by_status(SessionStatus::Active).await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+
+pub mod filter;
+pub mod session;
+pub mod session_manager;
+
+pub use filter::SessionFilter;
+pub use session::{
+    EntryType, LimitAction, LimitCheck, LimitExceeded, Session, SessionConfig, SessionEntry,
+    SessionId, SessionMetadata, SessionStatus, SessionType, Timestamp,
+};
+pub use session_manager::SessionManager;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/thulp-workspace/src/session.rs
+++ b/crates/thulp-workspace/src/session.rs
@@ -1,0 +1,763 @@
+//! Session types and management for thulp.
+//!
+//! This module provides session tracking for conversation history,
+//! evaluation runs, and skill execution sessions.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+/// Unique session identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionId(pub Uuid);
+
+impl SessionId {
+    /// Create a new random session ID.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Parse a session ID from a string.
+    pub fn from_string(s: &str) -> Result<Self, uuid::Error> {
+        Ok(Self(Uuid::parse_str(s)?))
+    }
+
+    /// Get the UUID as a string.
+    pub fn as_str(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl Default for SessionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for SessionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Timestamp in milliseconds since Unix epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Timestamp(pub u64);
+
+impl Timestamp {
+    /// Create a timestamp for the current time.
+    pub fn now() -> Self {
+        let duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO);
+        Self(duration.as_millis() as u64)
+    }
+
+    /// Create a timestamp from milliseconds.
+    pub fn from_millis(millis: u64) -> Self {
+        Self(millis)
+    }
+
+    /// Get the timestamp as milliseconds.
+    pub fn as_millis(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Default for Timestamp {
+    fn default() -> Self {
+        Self::now()
+    }
+}
+
+/// Type of session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionType {
+    /// Teacher demonstration session (for distillation).
+    TeacherDemo {
+        /// Task being demonstrated.
+        task: String,
+        /// Model used for demonstration.
+        model: String,
+    },
+
+    /// Skill evaluation run.
+    Evaluation {
+        /// Name of the skill being evaluated.
+        skill_name: String,
+        /// Number of test cases.
+        test_cases: usize,
+    },
+
+    /// Skill refinement session.
+    Refinement {
+        /// Name of the skill being refined.
+        skill_name: String,
+        /// Iteration number.
+        iteration: usize,
+    },
+
+    /// Generic conversation session.
+    Conversation {
+        /// Purpose of the conversation.
+        purpose: String,
+    },
+
+    /// Agent interaction session.
+    Agent {
+        /// Agent name or identifier.
+        agent_name: String,
+    },
+}
+
+/// Status of a session.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    /// Session is currently active.
+    #[default]
+    Active,
+    /// Session completed successfully.
+    Completed,
+    /// Session failed with an error.
+    Failed,
+    /// Session was cancelled.
+    Cancelled,
+    /// Session is paused.
+    Paused,
+}
+
+/// Session metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMetadata {
+    /// Unique session identifier.
+    pub id: SessionId,
+    /// Human-readable session name.
+    pub name: String,
+    /// Type of session.
+    pub session_type: SessionType,
+    /// When the session was created.
+    pub created_at: Timestamp,
+    /// When the session was last updated.
+    pub updated_at: Timestamp,
+    /// Current session status.
+    pub status: SessionStatus,
+    /// Tags for categorization.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Parent session ID (for linked sessions).
+    #[serde(default)]
+    pub parent_session: Option<SessionId>,
+}
+
+impl SessionMetadata {
+    /// Create new session metadata.
+    pub fn new(name: impl Into<String>, session_type: SessionType) -> Self {
+        let now = Timestamp::now();
+        Self {
+            id: SessionId::new(),
+            name: name.into(),
+            session_type,
+            created_at: now,
+            updated_at: now,
+            status: SessionStatus::Active,
+            tags: Vec::new(),
+            parent_session: None,
+        }
+    }
+
+    /// Add a tag.
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Set parent session.
+    pub fn with_parent(mut self, parent: SessionId) -> Self {
+        self.parent_session = Some(parent);
+        self
+    }
+}
+
+/// Type of entry in a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EntryType {
+    /// User message.
+    UserMessage,
+
+    /// Assistant/AI response.
+    AssistantMessage,
+
+    /// System message.
+    SystemMessage,
+
+    /// Tool invocation.
+    ToolCall {
+        /// Name of the tool called.
+        tool_name: String,
+        /// Whether the call succeeded.
+        success: bool,
+    },
+
+    /// Skill execution.
+    SkillExecution {
+        /// Name of the skill.
+        skill_name: String,
+        /// Whether execution succeeded.
+        success: bool,
+    },
+
+    /// Evaluation result.
+    EvaluationResult {
+        /// Overall score (0.0 - 1.0).
+        score: f64,
+        /// Detailed metrics.
+        metrics: HashMap<String, f64>,
+    },
+
+    /// System event (logging, state changes, etc.).
+    SystemEvent {
+        /// Event type/name.
+        event: String,
+    },
+}
+
+/// A single entry in a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEntry {
+    /// Unique entry identifier.
+    pub id: Uuid,
+    /// When the entry was created.
+    pub timestamp: Timestamp,
+    /// Type of entry.
+    pub entry_type: EntryType,
+    /// Entry content/data.
+    pub content: Value,
+}
+
+impl SessionEntry {
+    /// Create a new session entry.
+    pub fn new(entry_type: EntryType, content: Value) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            timestamp: Timestamp::now(),
+            entry_type,
+            content,
+        }
+    }
+
+    /// Create a user message entry.
+    pub fn user_message(content: impl Into<String>) -> Self {
+        Self::new(
+            EntryType::UserMessage,
+            serde_json::json!({ "text": content.into() }),
+        )
+    }
+
+    /// Create an assistant message entry.
+    pub fn assistant_message(content: impl Into<String>) -> Self {
+        Self::new(
+            EntryType::AssistantMessage,
+            serde_json::json!({ "text": content.into() }),
+        )
+    }
+
+    /// Create a tool call entry.
+    pub fn tool_call(tool_name: impl Into<String>, success: bool, result: Value) -> Self {
+        Self::new(
+            EntryType::ToolCall {
+                tool_name: tool_name.into(),
+                success,
+            },
+            result,
+        )
+    }
+
+    /// Create a skill execution entry.
+    pub fn skill_execution(skill_name: impl Into<String>, success: bool, result: Value) -> Self {
+        Self::new(
+            EntryType::SkillExecution {
+                skill_name: skill_name.into(),
+                success,
+            },
+            result,
+        )
+    }
+}
+
+/// Complete session data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    /// Session metadata.
+    pub metadata: SessionMetadata,
+    /// Session entries (conversation history, tool calls, etc.).
+    pub entries: Vec<SessionEntry>,
+    /// Session context data (key-value store).
+    #[serde(default)]
+    pub context: HashMap<String, Value>,
+}
+
+impl Session {
+    /// Create a new session.
+    pub fn new(name: impl Into<String>, session_type: SessionType) -> Self {
+        Self {
+            metadata: SessionMetadata::new(name, session_type),
+            entries: Vec::new(),
+            context: HashMap::new(),
+        }
+    }
+
+    /// Get the session ID.
+    pub fn id(&self) -> &SessionId {
+        &self.metadata.id
+    }
+
+    /// Get the session name.
+    pub fn name(&self) -> &str {
+        &self.metadata.name
+    }
+
+    /// Get the session status.
+    pub fn status(&self) -> SessionStatus {
+        self.metadata.status
+    }
+
+    /// Add an entry to the session.
+    pub fn add_entry(&mut self, entry: SessionEntry) {
+        self.entries.push(entry);
+        self.metadata.updated_at = Timestamp::now();
+    }
+
+    /// Add a user message.
+    pub fn add_user_message(&mut self, content: impl Into<String>) {
+        self.add_entry(SessionEntry::user_message(content));
+    }
+
+    /// Add an assistant message.
+    pub fn add_assistant_message(&mut self, content: impl Into<String>) {
+        self.add_entry(SessionEntry::assistant_message(content));
+    }
+
+    /// Set context value.
+    pub fn set_context(&mut self, key: impl Into<String>, value: Value) {
+        self.context.insert(key.into(), value);
+        self.metadata.updated_at = Timestamp::now();
+    }
+
+    /// Get context value.
+    pub fn get_context(&self, key: &str) -> Option<&Value> {
+        self.context.get(key)
+    }
+
+    /// Update session status.
+    pub fn set_status(&mut self, status: SessionStatus) {
+        self.metadata.status = status;
+        self.metadata.updated_at = Timestamp::now();
+    }
+
+    /// Mark session as completed.
+    pub fn complete(&mut self) {
+        self.set_status(SessionStatus::Completed);
+    }
+
+    /// Mark session as failed.
+    pub fn fail(&mut self) {
+        self.set_status(SessionStatus::Failed);
+    }
+
+    /// Count the number of turns in the session.
+    ///
+    /// A turn is defined as a user message followed by an assistant message.
+    /// This counts the number of complete turns.
+    pub fn turn_count(&self) -> u32 {
+        let mut turns = 0;
+        let mut awaiting_response = false;
+
+        for entry in &self.entries {
+            match &entry.entry_type {
+                EntryType::UserMessage => {
+                    awaiting_response = true;
+                }
+                EntryType::AssistantMessage => {
+                    if awaiting_response {
+                        turns += 1;
+                        awaiting_response = false;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        turns
+    }
+
+    /// Count user messages in the session.
+    pub fn user_message_count(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|e| matches!(e.entry_type, EntryType::UserMessage))
+            .count()
+    }
+
+    /// Count assistant messages in the session.
+    pub fn assistant_message_count(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|e| matches!(e.entry_type, EntryType::AssistantMessage))
+            .count()
+    }
+
+    /// Get the duration of the session.
+    pub fn duration(&self) -> Duration {
+        let start = self.metadata.created_at.as_millis();
+        let end = self.metadata.updated_at.as_millis();
+        Duration::from_millis(end.saturating_sub(start))
+    }
+}
+
+/// Configuration for session limits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionConfig {
+    /// Maximum number of turns allowed (None = unlimited).
+    pub max_turns: Option<u32>,
+    /// Maximum number of entries allowed (None = unlimited).
+    pub max_entries: Option<usize>,
+    /// Maximum session duration (None = unlimited).
+    pub max_duration: Option<Duration>,
+    /// Action to take when limit is reached.
+    pub limit_action: LimitAction,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            max_turns: None,
+            max_entries: None,
+            max_duration: None,
+            limit_action: LimitAction::Error,
+        }
+    }
+}
+
+impl SessionConfig {
+    /// Create a new session config with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set maximum turns.
+    pub fn with_max_turns(mut self, max: u32) -> Self {
+        self.max_turns = Some(max);
+        self
+    }
+
+    /// Set maximum entries.
+    pub fn with_max_entries(mut self, max: usize) -> Self {
+        self.max_entries = Some(max);
+        self
+    }
+
+    /// Set maximum duration.
+    pub fn with_max_duration(mut self, max: Duration) -> Self {
+        self.max_duration = Some(max);
+        self
+    }
+
+    /// Set limit action.
+    pub fn with_limit_action(mut self, action: LimitAction) -> Self {
+        self.limit_action = action;
+        self
+    }
+}
+
+/// Action to take when a session limit is reached.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LimitAction {
+    /// Return an error.
+    #[default]
+    Error,
+    /// End the session gracefully.
+    EndSession,
+    /// Ignore and continue (for soft limits).
+    Ignore,
+}
+
+/// Check result for session limits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LimitCheck {
+    /// Within limits.
+    Ok,
+    /// At the limit but not exceeded.
+    AtLimit,
+    /// Limit exceeded.
+    Exceeded(LimitExceeded),
+}
+
+/// Which limit was exceeded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LimitExceeded {
+    /// Turn limit exceeded.
+    Turns { current: u32, max: u32 },
+    /// Entry limit exceeded.
+    Entries { current: usize, max: usize },
+    /// Duration limit exceeded.
+    Duration { current: Duration, max: Duration },
+}
+
+impl Session {
+    /// Check if the session is within limits.
+    pub fn check_limits(&self, config: &SessionConfig) -> LimitCheck {
+        // Check turn limit
+        if let Some(max_turns) = config.max_turns {
+            let current = self.turn_count();
+            if current > max_turns {
+                return LimitCheck::Exceeded(LimitExceeded::Turns {
+                    current,
+                    max: max_turns,
+                });
+            }
+            if current == max_turns {
+                return LimitCheck::AtLimit;
+            }
+        }
+
+        // Check entry limit
+        if let Some(max_entries) = config.max_entries {
+            let current = self.entries.len();
+            if current > max_entries {
+                return LimitCheck::Exceeded(LimitExceeded::Entries {
+                    current,
+                    max: max_entries,
+                });
+            }
+            if current == max_entries {
+                return LimitCheck::AtLimit;
+            }
+        }
+
+        // Check duration limit
+        if let Some(max_duration) = config.max_duration {
+            let current = self.duration();
+            if current > max_duration {
+                return LimitCheck::Exceeded(LimitExceeded::Duration {
+                    current,
+                    max: max_duration,
+                });
+            }
+        }
+
+        LimitCheck::Ok
+    }
+
+    /// Check if the session is at its turn limit.
+    pub fn is_at_turn_limit(&self, config: &SessionConfig) -> bool {
+        if let Some(max_turns) = config.max_turns {
+            self.turn_count() >= max_turns
+        } else {
+            false
+        }
+    }
+
+    /// Get remaining turns before limit.
+    pub fn remaining_turns(&self, config: &SessionConfig) -> Option<u32> {
+        config
+            .max_turns
+            .map(|max| max.saturating_sub(self.turn_count()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_id() {
+        let id = SessionId::new();
+        let id_str = id.as_str();
+        let parsed = SessionId::from_string(&id_str).unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_timestamp() {
+        let ts1 = Timestamp::now();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let ts2 = Timestamp::now();
+        assert!(ts2.as_millis() > ts1.as_millis());
+    }
+
+    #[test]
+    fn test_session_creation() {
+        let session = Session::new(
+            "Test Session",
+            SessionType::Conversation {
+                purpose: "Testing".to_string(),
+            },
+        );
+
+        assert_eq!(session.name(), "Test Session");
+        assert_eq!(session.status(), SessionStatus::Active);
+        assert_eq!(session.entries.len(), 0);
+    }
+
+    #[test]
+    fn test_session_entries() {
+        let mut session = Session::new(
+            "Test",
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        );
+
+        session.add_user_message("Hello");
+        session.add_assistant_message("Hi there!");
+        session.add_user_message("How are you?");
+        session.add_assistant_message("I'm doing well!");
+
+        assert_eq!(session.entries.len(), 4);
+        assert_eq!(session.user_message_count(), 2);
+        assert_eq!(session.assistant_message_count(), 2);
+    }
+
+    #[test]
+    fn test_turn_counting() {
+        let mut session = Session::new(
+            "Test",
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        );
+
+        assert_eq!(session.turn_count(), 0);
+
+        session.add_user_message("Hello");
+        assert_eq!(session.turn_count(), 0); // No response yet
+
+        session.add_assistant_message("Hi!");
+        assert_eq!(session.turn_count(), 1); // First complete turn
+
+        session.add_user_message("How are you?");
+        session.add_assistant_message("Good!");
+        assert_eq!(session.turn_count(), 2); // Second complete turn
+    }
+
+    #[test]
+    fn test_session_limits() {
+        let mut session = Session::new(
+            "Test",
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        );
+
+        let config = SessionConfig::new().with_max_turns(2);
+
+        assert_eq!(session.check_limits(&config), LimitCheck::Ok);
+        assert_eq!(session.remaining_turns(&config), Some(2));
+        assert!(!session.is_at_turn_limit(&config));
+
+        // First turn
+        session.add_user_message("Hello");
+        session.add_assistant_message("Hi!");
+        assert_eq!(session.remaining_turns(&config), Some(1));
+
+        // Second turn (at limit)
+        session.add_user_message("How are you?");
+        session.add_assistant_message("Good!");
+        assert_eq!(session.check_limits(&config), LimitCheck::AtLimit);
+        assert!(session.is_at_turn_limit(&config));
+        assert_eq!(session.remaining_turns(&config), Some(0));
+
+        // Third turn (exceeded)
+        session.add_user_message("What's up?");
+        session.add_assistant_message("Nothing much!");
+        assert!(matches!(
+            session.check_limits(&config),
+            LimitCheck::Exceeded(LimitExceeded::Turns { current: 3, max: 2 })
+        ));
+    }
+
+    #[test]
+    fn test_session_context() {
+        let mut session = Session::new(
+            "Test",
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        );
+
+        session.set_context("key1", serde_json::json!("value1"));
+        session.set_context("key2", serde_json::json!(42));
+
+        assert_eq!(
+            session.get_context("key1"),
+            Some(&serde_json::json!("value1"))
+        );
+        assert_eq!(session.get_context("key2"), Some(&serde_json::json!(42)));
+        assert_eq!(session.get_context("key3"), None);
+    }
+
+    #[test]
+    fn test_session_status() {
+        let mut session = Session::new(
+            "Test",
+            SessionType::Conversation {
+                purpose: "Test".to_string(),
+            },
+        );
+
+        assert_eq!(session.status(), SessionStatus::Active);
+
+        session.complete();
+        assert_eq!(session.status(), SessionStatus::Completed);
+
+        session.fail();
+        assert_eq!(session.status(), SessionStatus::Failed);
+    }
+
+    #[test]
+    fn test_session_serialization() {
+        let mut session = Session::new(
+            "Test",
+            SessionType::TeacherDemo {
+                task: "Demo task".to_string(),
+                model: "gpt-4".to_string(),
+            },
+        );
+
+        session.add_user_message("Hello");
+        session.add_assistant_message("Hi!");
+        session.set_context("key", serde_json::json!("value"));
+
+        let json = serde_json::to_string(&session).unwrap();
+        let deserialized: Session = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.name(), session.name());
+        assert_eq!(deserialized.entries.len(), 2);
+        assert_eq!(
+            deserialized.get_context("key"),
+            Some(&serde_json::json!("value"))
+        );
+    }
+
+    #[test]
+    fn test_session_entry_types() {
+        let tool_entry =
+            SessionEntry::tool_call("my_tool", true, serde_json::json!({"result": "ok"}));
+        assert!(matches!(
+            tool_entry.entry_type,
+            EntryType::ToolCall { tool_name, success } if tool_name == "my_tool" && success
+        ));
+
+        let skill_entry = SessionEntry::skill_execution("my_skill", false, serde_json::json!({}));
+        assert!(matches!(
+            skill_entry.entry_type,
+            EntryType::SkillExecution { skill_name, success } if skill_name == "my_skill" && !success
+        ));
+    }
+}

--- a/crates/thulp-workspace/src/session_manager.rs
+++ b/crates/thulp-workspace/src/session_manager.rs
@@ -1,0 +1,674 @@
+//! Session manager for persisting and managing sessions.
+//!
+//! This module provides the `SessionManager` for creating, loading,
+//! saving, and querying sessions with file-based persistence.
+
+use crate::filter::SessionFilter;
+use crate::session::{
+    EntryType, Session, SessionEntry, SessionId, SessionMetadata, SessionStatus, SessionType,
+    Timestamp,
+};
+use crate::{Result, Workspace, WorkspaceError};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::fs;
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+/// Manager for session persistence and lifecycle.
+///
+/// The `SessionManager` provides file-based persistence for sessions,
+/// storing them in `{workspace}/.thulp/sessions/` as JSON files.
+///
+/// # Example
+///
+/// ```ignore
+/// use thulp_workspace::{Workspace, SessionManager, SessionType};
+///
+/// let workspace = Workspace::new("my-workspace", "My Workspace", PathBuf::from("."));
+/// let manager = SessionManager::new(&workspace).await?;
+///
+/// let session = manager.create_session("My Session", SessionType::Conversation {
+///     purpose: "Testing".to_string(),
+/// }).await?;
+///
+/// manager.add_entry(&session.id(), EntryType::UserMessage, json!({"text": "Hello"})).await?;
+/// ```
+pub struct SessionManager {
+    /// Directory where sessions are stored.
+    sessions_dir: PathBuf,
+    /// In-memory cache of active sessions.
+    active_sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+}
+
+impl SessionManager {
+    /// Create a new session manager for the given workspace.
+    ///
+    /// This will create the sessions directory if it doesn't exist.
+    pub async fn new(workspace: &Workspace) -> Result<Self> {
+        let sessions_dir = workspace.root.join(".thulp").join("sessions");
+        fs::create_dir_all(&sessions_dir).await?;
+
+        debug!(?sessions_dir, "Initialized session manager");
+
+        Ok(Self {
+            sessions_dir,
+            active_sessions: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Create a new session manager with a custom sessions directory.
+    pub async fn with_sessions_dir(sessions_dir: PathBuf) -> Result<Self> {
+        fs::create_dir_all(&sessions_dir).await?;
+
+        Ok(Self {
+            sessions_dir,
+            active_sessions: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Get the path to a session file.
+    fn session_path(&self, id: &SessionId) -> PathBuf {
+        self.sessions_dir.join(format!("{}.json", id))
+    }
+
+    /// Create a new session.
+    ///
+    /// The session is automatically persisted to disk and cached in memory.
+    pub async fn create_session(
+        &self,
+        name: impl Into<String>,
+        session_type: SessionType,
+    ) -> Result<Session> {
+        let session = Session::new(name, session_type);
+        let id = session.id().clone();
+
+        // Persist to disk
+        self.save_session_internal(&session).await?;
+
+        // Cache in memory
+        {
+            let mut sessions = self.active_sessions.write().await;
+            sessions.insert(id.clone(), session.clone());
+        }
+
+        info!(session_id = %id, "Created new session");
+        Ok(session)
+    }
+
+    /// Load a session from disk.
+    ///
+    /// If the session is already cached in memory, returns the cached version.
+    pub async fn load_session(&self, id: &SessionId) -> Result<Session> {
+        // Check cache first
+        {
+            let sessions = self.active_sessions.read().await;
+            if let Some(session) = sessions.get(id) {
+                return Ok(session.clone());
+            }
+        }
+
+        // Load from disk
+        let path = self.session_path(id);
+        let content = fs::read_to_string(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                WorkspaceError::NotFound(format!("Session {} not found", id))
+            } else {
+                WorkspaceError::Io(e)
+            }
+        })?;
+
+        let session: Session = serde_json::from_str(&content)
+            .map_err(|e| WorkspaceError::Serialization(e.to_string()))?;
+
+        // Cache for future access
+        {
+            let mut sessions = self.active_sessions.write().await;
+            sessions.insert(id.clone(), session.clone());
+        }
+
+        debug!(session_id = %id, "Loaded session from disk");
+        Ok(session)
+    }
+
+    /// Save a session to disk.
+    pub async fn save_session(&self, session: &Session) -> Result<()> {
+        self.save_session_internal(session).await?;
+
+        // Update cache
+        {
+            let mut sessions = self.active_sessions.write().await;
+            sessions.insert(session.id().clone(), session.clone());
+        }
+
+        Ok(())
+    }
+
+    /// Internal save without updating cache (to avoid deadlocks).
+    async fn save_session_internal(&self, session: &Session) -> Result<()> {
+        let path = self.session_path(session.id());
+        let content = serde_json::to_string_pretty(session)
+            .map_err(|e| WorkspaceError::Serialization(e.to_string()))?;
+
+        fs::write(&path, content).await?;
+        debug!(session_id = %session.id(), "Saved session to disk");
+        Ok(())
+    }
+
+    /// Add an entry to a session.
+    ///
+    /// The session is automatically saved after adding the entry.
+    pub async fn add_entry(
+        &self,
+        session_id: &SessionId,
+        entry_type: EntryType,
+        content: Value,
+    ) -> Result<SessionEntry> {
+        let entry = SessionEntry::new(entry_type, content);
+
+        {
+            let mut sessions = self.active_sessions.write().await;
+            if let Some(session) = sessions.get_mut(session_id) {
+                session.add_entry(entry.clone());
+                // Save to disk
+                self.save_session_internal(session).await?;
+            } else {
+                // Load from disk, add entry, save
+                drop(sessions); // Release lock before loading
+                let mut session = self.load_session(session_id).await?;
+                session.add_entry(entry.clone());
+                self.save_session(&session).await?;
+            }
+        }
+
+        debug!(session_id = %session_id, entry_id = %entry.id, "Added entry to session");
+        Ok(entry)
+    }
+
+    /// Complete a session.
+    ///
+    /// Marks the session as completed and saves it.
+    pub async fn complete_session(&self, session_id: &SessionId) -> Result<()> {
+        self.update_status(session_id, SessionStatus::Completed)
+            .await
+    }
+
+    /// Fail a session.
+    ///
+    /// Marks the session as failed and saves it.
+    pub async fn fail_session(&self, session_id: &SessionId) -> Result<()> {
+        self.update_status(session_id, SessionStatus::Failed).await
+    }
+
+    /// Cancel a session.
+    ///
+    /// Marks the session as cancelled and saves it.
+    pub async fn cancel_session(&self, session_id: &SessionId) -> Result<()> {
+        self.update_status(session_id, SessionStatus::Cancelled)
+            .await
+    }
+
+    /// Pause a session.
+    ///
+    /// Marks the session as paused and saves it.
+    pub async fn pause_session(&self, session_id: &SessionId) -> Result<()> {
+        self.update_status(session_id, SessionStatus::Paused).await
+    }
+
+    /// Resume a paused session.
+    ///
+    /// Marks the session as active and saves it.
+    pub async fn resume_session(&self, session_id: &SessionId) -> Result<()> {
+        self.update_status(session_id, SessionStatus::Active).await
+    }
+
+    /// Update session status.
+    async fn update_status(&self, session_id: &SessionId, status: SessionStatus) -> Result<()> {
+        let mut session = self.load_session(session_id).await?;
+        session.set_status(status);
+        self.save_session(&session).await?;
+
+        info!(session_id = %session_id, ?status, "Updated session status");
+        Ok(())
+    }
+
+    /// List all sessions, optionally filtered.
+    pub async fn list_sessions(
+        &self,
+        filter: Option<&SessionFilter>,
+    ) -> Result<Vec<SessionMetadata>> {
+        let mut metadata_list = Vec::new();
+
+        let mut entries = fs::read_dir(&self.sessions_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+
+            match fs::read_to_string(&path).await {
+                Ok(content) => {
+                    match serde_json::from_str::<Session>(&content) {
+                        Ok(session) => {
+                            let metadata = session.metadata.clone();
+
+                            // Apply filter if provided
+                            if let Some(filter) = filter {
+                                if filter.matches(&session) {
+                                    metadata_list.push(metadata);
+                                }
+                            } else {
+                                metadata_list.push(metadata);
+                            }
+                        }
+                        Err(e) => {
+                            warn!(path = ?path, error = %e, "Failed to parse session file");
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(path = ?path, error = %e, "Failed to read session file");
+                }
+            }
+        }
+
+        // Sort by updated_at descending (most recent first)
+        metadata_list.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+
+        Ok(metadata_list)
+    }
+
+    /// Delete a session.
+    ///
+    /// Removes the session from disk and cache.
+    pub async fn delete_session(&self, session_id: &SessionId) -> Result<()> {
+        // Remove from cache
+        {
+            let mut sessions = self.active_sessions.write().await;
+            sessions.remove(session_id);
+        }
+
+        // Remove from disk
+        let path = self.session_path(session_id);
+        if path.exists() {
+            fs::remove_file(&path).await?;
+            info!(session_id = %session_id, "Deleted session");
+        }
+
+        Ok(())
+    }
+
+    /// Check if a session exists.
+    pub async fn session_exists(&self, session_id: &SessionId) -> bool {
+        // Check cache
+        {
+            let sessions = self.active_sessions.read().await;
+            if sessions.contains_key(session_id) {
+                return true;
+            }
+        }
+
+        // Check disk
+        self.session_path(session_id).exists()
+    }
+
+    /// Get a session without loading it into cache.
+    ///
+    /// Useful for one-off reads where caching isn't beneficial.
+    pub async fn peek_session(&self, session_id: &SessionId) -> Result<Session> {
+        let path = self.session_path(session_id);
+        let content = fs::read_to_string(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                WorkspaceError::NotFound(format!("Session {} not found", session_id))
+            } else {
+                WorkspaceError::Io(e)
+            }
+        })?;
+
+        serde_json::from_str(&content).map_err(|e| WorkspaceError::Serialization(e.to_string()))
+    }
+
+    /// Evict a session from the in-memory cache.
+    ///
+    /// The session remains on disk but is removed from memory.
+    pub async fn evict_from_cache(&self, session_id: &SessionId) {
+        let mut sessions = self.active_sessions.write().await;
+        sessions.remove(session_id);
+    }
+
+    /// Clear all sessions from the in-memory cache.
+    pub async fn clear_cache(&self) {
+        let mut sessions = self.active_sessions.write().await;
+        sessions.clear();
+    }
+
+    /// Get the number of cached sessions.
+    pub async fn cached_session_count(&self) -> usize {
+        let sessions = self.active_sessions.read().await;
+        sessions.len()
+    }
+
+    /// Get all active sessions (in-memory only).
+    pub async fn active_sessions(&self) -> Vec<Session> {
+        let sessions = self.active_sessions.read().await;
+        sessions.values().cloned().collect()
+    }
+
+    /// Find sessions by tag.
+    pub async fn find_by_tag(&self, tag: &str) -> Result<Vec<SessionMetadata>> {
+        self.list_sessions(Some(&SessionFilter::HasTag(tag.to_string())))
+            .await
+    }
+
+    /// Find sessions by type.
+    pub async fn find_by_type(&self, session_type_name: &str) -> Result<Vec<SessionMetadata>> {
+        self.list_sessions(Some(&SessionFilter::ByTypeName(
+            session_type_name.to_string(),
+        )))
+        .await
+    }
+
+    /// Find sessions by status.
+    pub async fn find_by_status(&self, status: SessionStatus) -> Result<Vec<SessionMetadata>> {
+        self.list_sessions(Some(&SessionFilter::ByStatus(status)))
+            .await
+    }
+
+    /// Find sessions created after a timestamp.
+    pub async fn find_created_after(&self, timestamp: Timestamp) -> Result<Vec<SessionMetadata>> {
+        self.list_sessions(Some(&SessionFilter::CreatedAfter(timestamp)))
+            .await
+    }
+
+    /// Find sessions updated after a timestamp.
+    pub async fn find_updated_after(&self, timestamp: Timestamp) -> Result<Vec<SessionMetadata>> {
+        self.list_sessions(Some(&SessionFilter::UpdatedAfter(timestamp)))
+            .await
+    }
+
+    /// Get session count on disk.
+    pub async fn session_count(&self) -> Result<usize> {
+        let mut count = 0;
+        let mut entries = fs::read_dir(&self.sessions_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("json") {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+}
+
+impl std::fmt::Debug for SessionManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionManager")
+            .field("sessions_dir", &self.sessions_dir)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn create_test_manager() -> (SessionManager, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let sessions_dir = temp_dir.path().join("sessions");
+        let manager = SessionManager::with_sessions_dir(sessions_dir)
+            .await
+            .unwrap();
+        (manager, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_create_session() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let session = manager
+            .create_session(
+                "Test Session",
+                SessionType::Conversation {
+                    purpose: "Testing".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(session.name(), "Test Session");
+        assert_eq!(session.status(), SessionStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn test_load_session() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let created = manager
+            .create_session(
+                "Test Session",
+                SessionType::Conversation {
+                    purpose: "Testing".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Clear cache to force disk load
+        manager.clear_cache().await;
+
+        let loaded = manager.load_session(created.id()).await.unwrap();
+        assert_eq!(loaded.name(), created.name());
+        assert_eq!(loaded.id(), created.id());
+    }
+
+    #[tokio::test]
+    async fn test_add_entry() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let session = manager
+            .create_session(
+                "Test Session",
+                SessionType::Conversation {
+                    purpose: "Testing".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let entry = manager
+            .add_entry(
+                session.id(),
+                EntryType::UserMessage,
+                serde_json::json!({"text": "Hello"}),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(entry.entry_type, EntryType::UserMessage));
+
+        // Verify entry was persisted
+        manager.clear_cache().await;
+        let loaded = manager.load_session(session.id()).await.unwrap();
+        assert_eq!(loaded.entries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_complete_session() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let session = manager
+            .create_session(
+                "Test Session",
+                SessionType::Conversation {
+                    purpose: "Testing".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        manager.complete_session(session.id()).await.unwrap();
+
+        let loaded = manager.load_session(session.id()).await.unwrap();
+        assert_eq!(loaded.status(), SessionStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn test_list_sessions() {
+        let (manager, _temp) = create_test_manager().await;
+
+        // Create multiple sessions
+        manager
+            .create_session(
+                "Session 1",
+                SessionType::Conversation {
+                    purpose: "Test 1".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        manager
+            .create_session(
+                "Session 2",
+                SessionType::Conversation {
+                    purpose: "Test 2".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let sessions = manager.list_sessions(None).await.unwrap();
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_delete_session() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let session = manager
+            .create_session(
+                "Test Session",
+                SessionType::Conversation {
+                    purpose: "Testing".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        manager.delete_session(session.id()).await.unwrap();
+
+        assert!(!manager.session_exists(session.id()).await);
+    }
+
+    #[tokio::test]
+    async fn test_session_exists() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let session = manager
+            .create_session(
+                "Test Session",
+                SessionType::Conversation {
+                    purpose: "Testing".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(manager.session_exists(session.id()).await);
+
+        let fake_id = SessionId::new();
+        assert!(!manager.session_exists(&fake_id).await);
+    }
+
+    #[tokio::test]
+    async fn test_filter_by_status() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let session1 = manager
+            .create_session(
+                "Active Session",
+                SessionType::Conversation {
+                    purpose: "Test".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let session2 = manager
+            .create_session(
+                "Completed Session",
+                SessionType::Conversation {
+                    purpose: "Test".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        manager.complete_session(session2.id()).await.unwrap();
+
+        let active = manager.find_by_status(SessionStatus::Active).await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, session1.metadata.id);
+
+        let completed = manager
+            .find_by_status(SessionStatus::Completed)
+            .await
+            .unwrap();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].id, session2.metadata.id);
+    }
+
+    #[tokio::test]
+    async fn test_cache_operations() {
+        let (manager, _temp) = create_test_manager().await;
+
+        let session = manager
+            .create_session(
+                "Test Session",
+                SessionType::Conversation {
+                    purpose: "Testing".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(manager.cached_session_count().await, 1);
+
+        manager.evict_from_cache(session.id()).await;
+        assert_eq!(manager.cached_session_count().await, 0);
+
+        // Session should still exist on disk
+        assert!(manager.session_exists(session.id()).await);
+    }
+
+    #[tokio::test]
+    async fn test_session_count() {
+        let (manager, _temp) = create_test_manager().await;
+
+        assert_eq!(manager.session_count().await.unwrap(), 0);
+
+        manager
+            .create_session(
+                "Session 1",
+                SessionType::Conversation {
+                    purpose: "Test".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        manager
+            .create_session(
+                "Session 2",
+                SessionType::Conversation {
+                    purpose: "Test".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(manager.session_count().await.unwrap(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds several major features to thulp-skills and thulp-workspace crates:

### Skills Execution Abstraction
- Add `SkillExecutor` trait for pluggable execution strategies
- Add `ExecutionContext` for managing inputs/outputs/config between steps
- Add `StepResult` type for individual step outcomes with timing and retry info
- Add `DefaultSkillExecutor<T, H>` implementation using Transport trait

### Lifecycle Hooks
- Add `ExecutionHooks` trait for observing execution lifecycle
- Add `NoOpHooks`, `TracingHooks`, and `CompositeHooks` implementations

### Session Management (thulp-workspace)
- Add `Session` type with turn counting and limits
- Add `SessionManager` for async file-based persistence
- Add session filtering and querying capabilities

### Skill File Parsing (thulp-skill-files)
- Add SKILL.md file parsing with YAML frontmatter
- Add preprocessor for variable substitution ($ARGUMENTS, {{var}}, ${ENV})
- Add multi-directory skill discovery with scope priority

### Other Improvements
- Add timeout and retry support for skill execution
- Improve variable substitution to handle JSON object placeholders
- Add `Default` derive for `SkillStep`

## Testing
- All 54 tests pass in thulp-skills
- Clippy clean with `-D warnings`
- Code formatted with rustfmt