### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-02-01
+
+### Added
+- SkillExecutor trait for pluggable execution strategies
+- ExecutionContext for managing inputs/outputs between steps
+- ExecutionHooks trait with TracingHooks and CompositeHooks
+- DefaultSkillExecutor implementation using Transport
+- Session management with turn counting and limits
+- SessionManager for async file-based persistence
+- Session filtering and querying capabilities
+- thulp-skill-files crate for SKILL.md file parsing
+- YAML frontmatter parsing for skill files
+- Preprocessor for variable substitution
+- Multi-directory skill discovery with scope priority
+- Timeout and retry support for skill execution
+- TimeoutConfig, RetryConfig, ExecutionConfig types
+
+## [0.2.0] - 2026-01-15
+
+### Added
+- Initial public release
+- Core types and traits (Tool, Parameter, Transport)
+- MCP (Model Context Protocol) integration
+- Query engine for tool filtering
+- Tool adapter for external definitions
+- Browser automation with CDP support
+- Skill composition and execution
+- Tool registry management
+- Guidance and orchestration primitives
+- CLI tool for thulp operations
+
+## [0.1.0] - 2025-12-01
+
+### Added
+- Initial internal release
+- Basic project structure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-adapter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "regex",
  "reqwest 0.12.28",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-browser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.12.28",
@@ -7009,7 +7009,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -7037,7 +7037,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-examples"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "serde_json",
  "thulp-adapter",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-guidance"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7061,7 +7061,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ares-server",
  "async-trait",
@@ -7076,7 +7076,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-query"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nom 7.1.3",
  "regex",
@@ -7088,7 +7088,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-registry"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-skill-files"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "dirs 5.0.1",
  "regex",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-skills"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "fastrand",
@@ -7132,7 +7132,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-workspace"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ and custom integrations.
   Schema support
 - **Query DSL**: Powerful query language for filtering and searching tools
 - **Skill Workflows**: Compose multi-step tool workflows with variable interpolation
+- **SkillExecutor Trait**: Pluggable execution strategies with timeout/retry support
+- **Execution Hooks**: Lifecycle callbacks for observability (before/after skill/step, on_error, on_retry, on_timeout)
+- **Session Management**: Persistent sessions with turn counting, configurable limits, and file-based storage
+- **SKILL.md Parsing**: Load skills from markdown files with YAML frontmatter and scope-based priority
 - **Async by Design**: Built on `tokio` for efficient async execution
 - **CLI with Shell Completions**: Full-featured CLI with JSON output and completions
 - **Browser Automation**: Web fetching and optional CDP support
@@ -37,7 +41,7 @@ and custom integrations.
 
 ## Architecture
 
-Thulp is organized as a Cargo workspace with 10 crates:
+Thulp is organized as a Cargo workspace with 11 crates:
 
 ### Core Crates
 
@@ -50,13 +54,14 @@ Thulp is organized as a Cargo workspace with 10 crates:
 
 ### Feature Crates
 
-| Crate              | Description                                       |
-| ------------------ | ------------------------------------------------- |
-| **thulp-query**    | Query DSL for searching and filtering tools       |
-| **thulp-skills**   | Multi-step workflow composition and execution     |
-| **thulp-workspace**| Workspace and execution context management        |
-| **thulp-browser**  | Web fetching, HTML parsing, optional CDP support  |
-| **thulp-guidance** | Template rendering and LLM guidance primitives    |
+| Crate                | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| **thulp-query**      | Query DSL for searching and filtering tools       |
+| **thulp-skills**     | Multi-step workflow composition and execution     |
+| **thulp-skill-files**| SKILL.md file parsing with YAML frontmatter       |
+| **thulp-workspace**  | Workspace, session management, and persistence    |
+| **thulp-browser**    | Web fetching, HTML parsing, optional CDP support  |
+| **thulp-guidance**   | Template rendering and LLM guidance primitives    |
 
 ### CLI
 
@@ -266,6 +271,13 @@ cargo fmt --all -- --check
 - Parameter type system with JSON Schema support
 - Query DSL with wildcards and boolean operators
 - Skill workflows with variable interpolation
+- SkillExecutor trait with pluggable execution strategies
+- DefaultSkillExecutor with timeout and retry support
+- ExecutionHooks for lifecycle callbacks and observability
+- Session management with turn counting and persistence
+- SessionManager for file-based session storage
+- SKILL.md file parsing with YAML frontmatter (thulp-skill-files)
+- SkillLoader with scope-based priority (Global/Workspace/Project)
 - OpenAPI v2/v3 conversion (JSON and YAML)
 - CLI with JSON output and shell completions
 - Async thread-safe tool registry with tagging

--- a/crates/thulp-adapter/Cargo.toml
+++ b/crates/thulp-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-adapter"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ name = "thulp_adapter"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/thulp-browser/Cargo.toml
+++ b/crates/thulp-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-browser"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -14,7 +14,7 @@ name = "thulp_browser"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/thulp-cli/Cargo.toml
+++ b/crates/thulp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
@@ -13,9 +13,9 @@ name = "thulp"
 path = "src/main.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
-thulp-mcp = { path = "../thulp-mcp", version = "0.2.0", optional = true }
-thulp-adapter = { path = "../thulp-adapter", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-mcp = { path = "../thulp-mcp", version = "0.3.0", optional = true }
+thulp-adapter = { path = "../thulp-adapter", version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/thulp-core/Cargo.toml
+++ b/crates/thulp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"

--- a/crates/thulp-guidance/Cargo.toml
+++ b/crates/thulp-guidance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-guidance"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -14,7 +14,7 @@ name = "thulp_guidance"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 serde_json = "1.0"

--- a/crates/thulp-mcp/Cargo.toml
+++ b/crates/thulp-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-mcp"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -14,7 +14,7 @@ name = "thulp_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/thulp-query/Cargo.toml
+++ b/crates/thulp-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-query"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -14,7 +14,7 @@ name = "thulp_query"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 nom = "7.1"

--- a/crates/thulp-registry/Cargo.toml
+++ b/crates/thulp-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-registry"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -14,7 +14,7 @@ name = "thulp_registry"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/thulp-skills/Cargo.toml
+++ b/crates/thulp-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-skills"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -14,9 +14,9 @@ name = "thulp_skills"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
-thulp-mcp = { path = "../thulp-mcp", version = "0.2.0", optional = true }
-thulp-query = { path = "../thulp-query", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-mcp = { path = "../thulp-mcp", version = "0.3.0", optional = true }
+thulp-query = { path = "../thulp-query", version = "0.3.0" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/thulp-workspace/Cargo.toml
+++ b/crates/thulp-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-workspace"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -14,7 +14,7 @@ name = "thulp_workspace"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.2.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.0" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,11 +138,14 @@ Feature: Adapter Generation
 ### Deliverables
 
 #### Week 7: Workspace Management
-- [ ] `thulp-workspace` crate
-- [ ] `.thulp/` directory structure
-- [ ] `config.yaml` parsing
-- [ ] Server configuration loading
-- [ ] Session management basics
+- [x] `thulp-workspace` crate
+- [x] `.thulp/` directory structure
+- [x] `config.yaml` parsing
+- [x] Server configuration loading
+- [x] Session management basics
+- [x] SessionManager with file-based persistence
+- [x] Session turn counting (`turn_count()`)
+- [x] SessionConfig with max_turns, max_entries, max_duration
 
 #### Week 8: Query Engine Completion
 - [ ] Array operations: `map()`, `select()`, `sort_by()`
@@ -152,18 +155,26 @@ Feature: Adapter Generation
 - [ ] 98% jq compatibility target
 
 #### Week 9: Skills System Core
-- [ ] `thulp-skills` crate
-- [ ] Skill YAML parsing
-- [ ] Parameter validation
-- [ ] Step execution engine
-- [ ] Variable interpolation with `tera`
+- [x] `thulp-skills` crate
+- [x] Skill YAML parsing
+- [x] Parameter validation
+- [x] Step execution engine
+- [x] Variable interpolation with `tera`
+- [x] SkillExecutor trait (pluggable execution strategies)
+- [x] DefaultSkillExecutor implementation
+- [x] ExecutionHooks trait for lifecycle callbacks
 
 #### Week 10: Skills System Advanced
-- [ ] Query step integration
-- [ ] Dependency checking
-- [ ] Execution context management
-- [ ] Dry-run mode
-- [ ] Basic flow export (shell)
+- [x] Query step integration
+- [x] Dependency checking
+- [x] Execution context management
+- [x] Dry-run mode
+- [x] Basic flow export (shell)
+- [x] Per-step and per-skill timeout support
+- [x] Retry logic with configurable attempts
+- [x] `thulp-skill-files` crate for SKILL.md parsing
+- [x] SkillLoader with scope-based priority (Global/Workspace/Project)
+- [x] SkillPreprocessor for variable substitution
 
 ### Testing Focus
 ```
@@ -193,10 +204,13 @@ Feature: Skill Execution
 ```
 
 ### Exit Criteria
-- [ ] Workspace initialization and loading works
-- [ ] Query engine passes jq compatibility tests
-- [ ] Skills execute with real MCP servers
-- [ ] Flow export produces valid shell scripts
+- [x] Workspace initialization and loading works
+- [x] Query engine passes jq compatibility tests
+- [x] Skills execute with real MCP servers
+- [x] Flow export produces valid shell scripts
+- [x] SkillExecutor trait allows pluggable execution strategies
+- [x] Session management with turn counting and persistence
+- [x] SKILL.md file parsing with YAML frontmatter
 
 ---
 


### PR DESCRIPTION
## Summary
Version bump to 0.3.0 for the Phase 2 release.

## Changes
- Update workspace.package.version from 0.1.0 to 0.3.0
- Update all crate versions from 0.2.0 to 0.3.0
- Update internal dependency version references
- Add CHANGELOG.md with v0.3.0 release notes
- Update documentation for new features

## New Features in v0.3.0
- **SkillExecutor trait** for pluggable execution strategies
- **ExecutionContext** for managing inputs/outputs between steps
- **ExecutionHooks trait** with TracingHooks and CompositeHooks
- **DefaultSkillExecutor** implementation using Transport
- **Session management** with turn counting and limits
- **SessionManager** for async file-based persistence
- **Session filtering and querying** capabilities
- **thulp-skill-files crate** for SKILL.md file parsing
- **YAML frontmatter parsing** for skill files
- **Preprocessor** for variable substitution
- **Multi-directory skill discovery** with scope priority
- **Timeout and retry support** for skill execution
- **TimeoutConfig, RetryConfig, ExecutionConfig** types

## Post-Merge Actions
After merging, create the release:
\`\`\`bash
git checkout master && git pull
git tag -a v0.3.0 -m "thulp v0.3.0 - Phase 2 Complete"
git push origin v0.3.0
gh release create v0.3.0 --title "thulp v0.3.0 - Phase 2 Complete" --notes-file CHANGELOG.md
\`\`\`