### PR TITLE
fix: add missing SkillStep fields to skills example

### DIFF
--- a/examples/skills_example.rs
+++ b/examples/skills_example.rs
@@ -23,6 +23,8 @@ fn main() {
             "limit": "{{max_results}}"
         }),
         continue_on_error: false,
+        timeout_secs: None,
+        max_retries: None,
     })
     .with_step(SkillStep {
         name: "summarize".to_string(),
@@ -32,6 +34,8 @@ fn main() {
             "format": "bullet_points"
         }),
         continue_on_error: false,
+        timeout_secs: None,
+        max_retries: None,
     })
     .with_step(SkillStep {
         name: "notify".to_string(),
@@ -41,6 +45,8 @@ fn main() {
             "channel": "results"
         }),
         continue_on_error: true, // Continue even if notification fails
+        timeout_secs: None,
+        max_retries: None,
     });
 
     println!("Skill: {} - {}", skill.name, skill.description);
@@ -67,12 +73,16 @@ fn main() {
             tool: "http_get".to_string(),
             arguments: json!({"url": "{{url}}"}),
             continue_on_error: false,
+            timeout_secs: None,
+            max_retries: None,
         })
         .with_step(SkillStep {
             name: "parse".to_string(),
             tool: "html_parser".to_string(),
             arguments: json!({"html": "{{fetch.body}}"}),
             continue_on_error: false,
+            timeout_secs: None,
+            max_retries: None,
         });
 
     let analyze_skill = Skill::new("analyze_code", "Analyze source code quality")
@@ -82,12 +92,16 @@ fn main() {
             tool: "read_file".to_string(),
             arguments: json!({"path": "{{file_path}}"}),
             continue_on_error: false,
+            timeout_secs: None,
+            max_retries: None,
         })
         .with_step(SkillStep {
             name: "analyze".to_string(),
             tool: "code_analyzer".to_string(),
             arguments: json!({"code": "{{read.content}}"}),
             continue_on_error: false,
+            timeout_secs: None,
+            max_retries: None,
         });
 
     registry.register(skill);


### PR DESCRIPTION
## Summary

- Fixes CI compilation errors by adding the missing `timeout_secs` and `max_retries` fields to all `SkillStep` initializations in `examples/skills_example.rs`

## Details

After Phase 2 (DIR-47 Timeout/Retry Support), the `SkillStep` struct gained two new required fields:
- `timeout_secs: Option<u64>`
- `max_retries: Option<usize>`

The skills example was not updated, causing CI to fail on all platforms with:
```
error[E0063]: missing fields `max_retries` and `timeout_secs` in initializer of `SkillStep`
```

This PR adds both fields (set to `None`) to all 7 `SkillStep` initializations in the example.