### PR TITLE
docs: update status to reflect v0.3.0 release and completed phases

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,13 +1,14 @@
 # Thulp Implementation Status
 
-**Last Updated**: January 15, 2026
+**Last Updated**: February 1, 2026
 
 ## Summary
 
-- **Total Tests**: 183 passing
+- **Total Tests**: 190+ passing
 - **Clippy**: Clean (no warnings)
 - **Build Status**: Successful
-- **Crates**: 10 crates in workspace
+- **Crates**: 11 crates in workspace (added thulp-skill-files)
+- **Latest Release**: v0.3.0 on crates.io
 
 ## Completed Work
 
@@ -60,6 +61,20 @@
 - ✅ Authentication config parsing (API key, HTTP, OAuth2)
 - ✅ Request body handling
 - ✅ YAML config generation
+
+### Phase 2.5: Reliability & Sessions (v0.3.0) - COMPLETE
+
+- ✅ `SkillExecutor` trait for pluggable execution strategies (DIR-46)
+- ✅ `DefaultSkillExecutor` implementation
+- ✅ `ExecutionHooks` trait with `NoOpHooks`, `TracingHooks`, `CompositeHooks`
+- ✅ Per-step and per-skill timeout support (DIR-47)
+- ✅ Retry logic with configurable attempts
+- ✅ `SessionManager` with file-based persistence (DIR-48)
+- ✅ Session turn counting via `turn_count()` (DIR-96)
+- ✅ `SessionConfig` with max_turns, max_entries, max_duration
+- ✅ `thulp-skill-files` crate for SKILL.md parsing
+- ✅ `SkillLoader` with scope-based priority (Global/Workspace/Project)
+- ✅ `SkillPreprocessor` for variable substitution
 
 ### Phase 3: Workspace & Skills - COMPLETE
 
@@ -163,4 +178,6 @@ cargo fmt --all
 
 ## Version History
 
+- **0.3.0** (February 2026): Reliability release - SkillExecutor trait, timeout/retry, session management
+- **0.2.0** (January 2026): MCP enhancements, skill file parsing
 - **0.1.0** (January 2026): Initial release with complete core functionality

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,8 @@
 
 This roadmap outlines the phased development of Thulp with TDD/BDD methodology. The integration of **rs-utcp** significantly reduces development time for Phase 2 (MCP and Adapters).
 
+**Status**: Phases 1-3 COMPLETE. Phase 4-5 in progress.
+**Current Version**: 0.3.0 (released to crates.io)
 **Total Estimated Duration**: 14-16 weeks (reduced from original 19+ weeks due to rs-utcp)
 
 ## Development Principles
@@ -16,7 +18,7 @@ This roadmap outlines the phased development of Thulp with TDD/BDD methodology. 
 
 ---
 
-## Phase 1: Foundation (Weeks 1-3)
+## Phase 1: Foundation (Weeks 1-3) ✅ COMPLETE
 
 ### Goals
 - Establish project structure
@@ -26,22 +28,22 @@ This roadmap outlines the phased development of Thulp with TDD/BDD methodology. 
 ### Deliverables
 
 #### Week 1: Project Setup
-- [ ] Initialize Cargo workspace
-- [ ] Set up CI/CD (GitHub Actions)
-- [ ] Configure test infrastructure (unit, integration, BDD)
-- [ ] Create `thulp-core` crate skeleton
+- [x] Initialize Cargo workspace
+- [x] Set up CI/CD (GitHub Actions)
+- [x] Configure test infrastructure (unit, integration, BDD)
+- [x] Create `thulp-core` crate skeleton
 
 #### Week 2: Core Types
-- [ ] `ToolDefinition`, `ToolCall`, `ToolResult` types
-- [ ] `Error` types with `thiserror`
-- [ ] Core traits: `Tool`, `Transport`
-- [ ] Serialization with `serde`
+- [x] `ToolDefinition`, `ToolCall`, `ToolResult` types
+- [x] `Error` types with `thiserror`
+- [x] Core traits: `Tool`, `Transport`
+- [x] Serialization with `serde`
 
 #### Week 3: Query Engine Foundation
-- [ ] `thulp-query` crate setup
-- [ ] Parser foundation with `nom`
-- [ ] Basic operations: `.`, `.field`, `.[n]`
-- [ ] Pipe operator `|`
+- [x] `thulp-query` crate setup
+- [x] Parser foundation with `nom`
+- [x] Basic operations: `.`, `.field`, `.[n]`
+- [x] Pipe operator `|`
 
 ### Testing Focus
 ```
@@ -56,7 +58,7 @@ Unit tests: Parser tests for thulp-query
 
 ---
 
-## Phase 2: MCP & Adapters (Weeks 4-6)
+## Phase 2: MCP & Adapters (Weeks 4-6) ✅ COMPLETE
 
 ### Goals
 - Integrate rs-utcp for MCP protocol
@@ -66,24 +68,24 @@ Unit tests: Parser tests for thulp-query
 ### Deliverables
 
 #### Week 4: MCP Client (rs-utcp Integration)
-- [ ] `thulp-mcp` crate with rs-utcp dependency
-- [ ] `McpClient` wrapper around `rs_utcp::transports::mcp`
-- [ ] STDIO transport: `connect_stdio()`
-- [ ] Tool discovery: `list_tools()`
-- [ ] Tool execution: `call_tool()`
+- [x] `thulp-mcp` crate with rs-utcp dependency
+- [x] `McpClient` wrapper around `rs_utcp::transports::mcp`
+- [x] STDIO transport: `connect_stdio()`
+- [x] Tool discovery: `list_tools()`
+- [x] Tool execution: `call_tool()`
 
 #### Week 5: MCP Client (Continued)
-- [ ] SSE transport: `connect_sse()`
-- [ ] Resource access: `list_resources()`, `read_resource()`
-- [ ] Connection lifecycle management
-- [ ] Error handling and reconnection
+- [x] SSE transport: `connect_sse()`
+- [x] Resource access: `list_resources()`, `read_resource()`
+- [x] Connection lifecycle management
+- [x] Error handling and reconnection
 
 #### Week 6: Adapter Framework
-- [ ] `thulp-adapter` crate with rs-utcp dependency
-- [ ] `AdapterGenerator` wrapper around `rs_utcp::openapi::OpenApiConverter`
-- [ ] OpenAPI 3.x support
-- [ ] Auth configuration extraction
-- [ ] Adapter serialization to YAML
+- [x] `thulp-adapter` crate with rs-utcp dependency
+- [x] `AdapterGenerator` wrapper around `rs_utcp::openapi::OpenApiConverter`
+- [x] OpenAPI 3.x support
+- [x] Auth configuration extraction
+- [x] Adapter serialization to YAML
 
 ### rs-utcp Integration Points
 
@@ -128,7 +130,7 @@ Feature: Adapter Generation
 
 ---
 
-## Phase 3: Workspace & Skills (Weeks 7-10)
+## Phase 3: Workspace & Skills (Weeks 7-10) ✅ COMPLETE
 
 ### Goals
 - Project structure management
@@ -148,11 +150,11 @@ Feature: Adapter Generation
 - [x] SessionConfig with max_turns, max_entries, max_duration
 
 #### Week 8: Query Engine Completion
-- [ ] Array operations: `map()`, `select()`, `sort_by()`
-- [ ] Object construction: `{key: .value}`
-- [ ] Conditionals: `if-then-else`, `//`
-- [ ] String functions: `split()`, `join()`, `test()`
-- [ ] 98% jq compatibility target
+- [x] Array operations: `map()`, `select()`, `sort_by()`
+- [x] Object construction: `{key: .value}`
+- [x] Conditionals: `if-then-else`, `//`
+- [x] String functions: `split()`, `join()`, `test()`
+- [x] 98% jq compatibility target
 
 #### Week 9: Skills System Core
 - [x] `thulp-skills` crate


### PR DESCRIPTION
## Summary

- Updated `docs/IMPLEMENTATION_STATUS.md` to reflect v0.3.0 release
- Updated `docs/ROADMAP.md` to mark Phases 1-3 as complete

## Changes

### IMPLEMENTATION_STATUS.md
- Updated date to February 1, 2026
- Updated test count to 190+
- Added 11th crate (thulp-skill-files)
- Added Phase 2.5 section documenting reliability features:
  - SkillExecutor trait
  - Timeout/retry support
  - Session management
  - Turn counting
- Added version history

### ROADMAP.md
- Added status header showing Phases 1-3 complete, v0.3.0 released
- Marked all Phase 1-3 checklist items as complete