### PR TITLE
docs: README rewrite + Zola gh-pages site + logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,74 @@
-# thulp
+<p align="center">
+  <img src="docs/static/img/thulp-logo.svg" width="128" alt="thulp">
+</p>
 
-[![CI](https://github.com/dirmacs/thulp/actions/workflows/ci.yml/badge.svg)](https://github.com/dirmacs/thulp/actions/workflows/ci.yml)
-[![crates.io](https://img.shields.io/crates/v/thulp-core.svg)](https://crates.io/crates/thulp-core)
-[![docs.rs](https://docs.rs/thulp-core/badge.svg)](https://docs.rs/thulp-core)
-[![License](https://img.shields.io/crates/l/thulp-core.svg)](LICENSE-MIT)
+<h1 align="center">Thulp</h1>
 
-## Execution Context Engineering Platform for AI Agents
+<p align="center">
+  Execution context engineering for AI agents. Rust. 11 crates. 311 tests.<br>
+  One interface for tool discovery, validation, execution, and multi-step workflows.
+</p>
 
-Thulp is a Rust-based toolkit for building AI agents with rich execution
-contexts. It provides abstractions for tool discovery, execution, workspace
-management, and integration with the Model Context Protocol (MCP) via the
-[UTCP](https://github.com/universal-tool-calling-protocol/rs-utcp)
-(Universal Tool Calling Protocol) implementation.
+<p align="center">
+  <a href="https://crates.io/crates/thulp-core"><img src="https://img.shields.io/crates/v/thulp-core.svg" alt="crates.io"></a>
+  <a href="https://github.com/dirmacs/thulp/actions/workflows/ci.yml"><img src="https://github.com/dirmacs/thulp/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://docs.rs/thulp-core"><img src="https://docs.rs/thulp-core/badge.svg" alt="docs.rs"></a>
+  <img src="https://img.shields.io/badge/crates-11-blue.svg" alt="11 crates">
+  <img src="https://img.shields.io/badge/tests-311-brightgreen.svg" alt="311 tests">
+  <img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-yellow.svg" alt="License">
+</p>
 
-## Overview
+---
 
-Thulp enables AI agents to interact with external tools and services through a
-unified interface. It handles the complexity of tool discovery, validation,
-execution, and result handling while providing extensibility through adapters
-and custom integrations.
+**Thulp** gives AI agents a unified way to discover, validate, and execute tools — whether they're local functions, [MCP](https://modelcontextprotocol.io/) servers, or OpenAPI endpoints. It handles parameter validation, multi-step skill workflows, session persistence, and query-based tool filtering. Built on [rs-utcp](https://github.com/universal-tool-calling-protocol/rs-utcp) for protocol transport.
 
-### Key Features
+Built by [DIRMACS](https://dirmacs.com).
 
-- **Unified Tool Abstraction**: Consistent interface for defining, validating,
-  and executing tools
-- **MCP Integration**: Full Model Context Protocol support via `rs-utcp` UTCP
-  implementation (tools, resources, prompts)
-- **Type-Safe Parameters**: Strongly-typed parameter validation with JSON
-  Schema support
-- **Query DSL**: Powerful query language for filtering and searching tools
-- **Skill Workflows**: Compose multi-step tool workflows with variable interpolation
-- **SkillExecutor Trait**: Pluggable execution strategies with timeout/retry support
-- **Execution Hooks**: Lifecycle callbacks for observability (before/after skill/step, on_error, on_retry, on_timeout)
-- **Session Management**: Persistent sessions with turn counting, configurable limits, and file-based storage
-- **SKILL.md Parsing**: Load skills from markdown files with YAML frontmatter and scope-based priority
-- **Async by Design**: Built on `tokio` for efficient async execution
-- **CLI with Shell Completions**: Full-featured CLI with JSON output and completions
-- **Browser Automation**: Web fetching and optional CDP support
-- **Comprehensive Testing**: 183 tests with edge-case coverage
-
-## Architecture
-
-Thulp is organized as a Cargo workspace with 11 crates:
-
-### Core Crates
-
-| Crate              | Description                                       |
-| ------------------ | ------------------------------------------------- |
-| **thulp-core**     | Core types and traits (`ToolDefinition`, etc.)    |
-| **thulp-mcp**      | MCP transport (STDIO/HTTP, tools, resources)      |
-| **thulp-adapter**  | OpenAPI v2/v3 to tool definition conversion       |
-| **thulp-registry** | Async thread-safe tool registry with tagging      |
-
-### Feature Crates
-
-| Crate                | Description                                       |
-| -------------------- | ------------------------------------------------- |
-| **thulp-query**      | Query DSL for searching and filtering tools       |
-| **thulp-skills**     | Multi-step workflow composition and execution     |
-| **thulp-skill-files**| SKILL.md file parsing with YAML frontmatter       |
-| **thulp-workspace**  | Workspace, session management, and persistence    |
-| **thulp-browser**    | Web fetching, HTML parsing, optional CDP support  |
-| **thulp-guidance**   | Template rendering and LLM guidance primitives    |
-
-### CLI
-
-| Crate         | Description                                        |
-| ------------- | -------------------------------------------------- |
-| **thulp-cli** | CLI with JSON output and shell completions         |
-
-## Installation
-
-### Install CLI
+## Install
 
 ```bash
 cargo install thulp-cli
 ```
 
-### Add as Dependency
-
 ```toml
+# Or as a library
 [dependencies]
-thulp-core = "0.2"
-thulp-mcp = "0.2"
-thulp-query = "0.2"
+thulp-core = "0.3"
+thulp-mcp = "0.3"
+thulp-skills = "0.3"
 ```
 
-For MCP with Ares server support:
+## Why Thulp?
 
-```toml
-[dependencies]
-thulp-mcp = { version = "0.2", features = ["ares"] }
-```
+Every AI agent needs tools. But each agent framework invents its own tool format, validation, and execution layer. Thulp standardizes this:
+
+- **One tool definition** works across local functions, MCP servers, and OpenAPI specs
+- **Type-safe parameters** with JSON Schema validation — catch errors before execution
+- **Skill workflows** compose multi-step tool chains with `{{variable}}` interpolation, timeout/retry, and hooks
+- **Query DSL** finds tools by name, parameter count, or tags — `name:search and min:2`
+- **Session persistence** tracks turns, enforces limits, stores results to disk
+
+No runtime overhead. No framework lock-in. Pure Rust async.
+
+## Workspace (11 crates)
+
+| Crate | What | Tests |
+|-------|------|-------|
+| **thulp-core** | Types, traits, parameter validation, JSON Schema | 70 |
+| **thulp-mcp** | MCP transport (STDIO/HTTP), tools, resources, prompts | 39 |
+| **thulp-skills** | Multi-step workflows, executor trait, hooks, retry | 54 |
+| **thulp-skill-files** | SKILL.md parsing, YAML frontmatter, scope priority | 23 |
+| **thulp-query** | Query DSL with nom parser, wildcards, boolean ops | 19 |
+| **thulp-workspace** | Sessions, turn counting, file persistence | 6 |
+| **thulp-adapter** | OpenAPI v2/v3 to tool conversion (JSON + YAML) | 10 |
+| **thulp-registry** | Async thread-safe tool registry with tagging | 8 |
+| **thulp-browser** | Web fetching, HTML parsing, optional CDP | 7 |
+| **thulp-guidance** | Template rendering, LLM guidance primitives | 6 |
+| **thulp-cli** | CLI with JSON output and shell completions | 36 |
 
 ## Quick Start
 
-### Defining a Tool
+### Define a tool
 
 ```rust
 use thulp_core::{ToolDefinition, Parameter, ParameterType};
@@ -104,7 +77,6 @@ let tool = ToolDefinition::builder("search")
     .description("Search for information")
     .parameter(
         Parameter::builder("query")
-            .description("Search query")
             .param_type(ParameterType::String)
             .required(true)
             .build()
@@ -112,28 +84,37 @@ let tool = ToolDefinition::builder("search")
     .build();
 ```
 
-### Connecting to an MCP Server
+### Connect to an MCP server
 
 ```rust
 use thulp_mcp::McpClient;
 
-// Connect via HTTP
-let client = McpClient::connect_http("server", "http://localhost:8080".to_string()).await?;
-
-// Or via STDIO
-let client = McpClient::connect_stdio(
-    "server",
-    "path/to/mcp-server".to_string(),
-    None
-).await?;
-
-// List available tools
+let client = McpClient::connect_stdio("server", "mcp-server", None).await?;
 let tools = client.list_tools().await?;
-
-// Execute a tool
-let result = client.call(&ToolCall::builder("tool_name")
-    .arg_str("param", "value")
+let result = client.call(&ToolCall::builder("search")
+    .arg_str("query", "rust async")
     .build()).await?;
+```
+
+### Compose a skill workflow
+
+```rust
+use thulp_skills::{Skill, SkillStep};
+
+let skill = Skill::new("search_and_summarize", "Search and summarize")
+    .with_input("query")
+    .with_step(SkillStep {
+        name: "search".into(),
+        tool: "web_search".into(),
+        arguments: json!({"query": "{{query}}"}),
+        continue_on_error: false,
+    })
+    .with_step(SkillStep {
+        name: "summarize".into(),
+        tool: "summarize".into(),
+        arguments: json!({"text": "{{search.results}}"}),
+        continue_on_error: false,
+    });
 ```
 
 ### Query DSL
@@ -141,188 +122,76 @@ let result = client.call(&ToolCall::builder("tool_name")
 ```rust
 use thulp_query::{parse_query, QueryBuilder};
 
-// Parse natural language query
 let criteria = parse_query("name:search and min:2")?;
 let matches: Vec<_> = tools.iter().filter(|t| criteria.matches(t)).collect();
-
-// Or use the builder
-let query = QueryBuilder::new()
-    .name("file")
-    .min_parameters(1)
-    .build();
-let results = query.execute(&tools);
 ```
 
-### Skill Workflows
-
-```rust
-use thulp_skills::{Skill, SkillStep};
-
-let skill = Skill::new("search_and_summarize", "Search and summarize results")
-    .with_input("query")
-    .with_step(SkillStep {
-        name: "search".to_string(),
-        tool: "web_search".to_string(),
-        arguments: json!({"query": "{{query}}"}),
-        continue_on_error: false,
-    })
-    .with_step(SkillStep {
-        name: "summarize".to_string(),
-        tool: "summarize".to_string(),
-        arguments: json!({"text": "{{search.results}}"}),
-        continue_on_error: false,
-    });
-```
-
-## CLI Usage
+## CLI
 
 ```bash
-# List tools
-thulp tools list
-thulp tools list --output json
-
-# Show tool details
-thulp tools show <tool-name>
-
-# Validate tool arguments
-thulp tools validate <tool-name> --args '{"param": "value"}'
-
-# Convert OpenAPI spec to tools
-thulp convert openapi spec.yaml --output tools.yaml
-
-# Run demo
-thulp demo
-
-# Generate shell completions
+thulp tools list                                      # list available tools
+thulp tools list --output json                        # JSON output
+thulp tools show <name>                               # tool details
+thulp tools validate <name> --args '{"q": "rust"}'    # validate arguments
+thulp convert openapi spec.yaml --output tools.yaml   # OpenAPI conversion
+thulp demo                                            # interactive demo
 thulp completions bash > ~/.local/share/bash-completion/completions/thulp
-thulp completions powershell >> $PROFILE
 ```
 
-## Examples
+## Architecture
 
-Thulp includes 6 comprehensive examples:
-
-```bash
-# Core tool types
-cargo run --example tool_definition
-
-# OpenAPI conversion
-cargo run --example adapter
-
-# MCP integration
-cargo run --example mcp --features mcp
-
-# Query DSL
-cargo run --example query
-
-# Skill workflows
-cargo run --example skills
-
-# Async registry
-cargo run --example registry
 ```
+thulp/
+  crates/
+    thulp-core/        # types, traits, validation (zero dependencies on other thulp crates)
+    thulp-mcp/         # MCP client (rs-utcp, STDIO + HTTP transport)
+    thulp-skills/      # workflow engine (executor, hooks, retry, timeout)
+    thulp-skill-files/ # SKILL.md parser (YAML frontmatter, scope priority)
+    thulp-query/       # DSL parser (nom, wildcards, boolean operators)
+    thulp-workspace/   # sessions, persistence, turn counting
+    thulp-adapter/     # OpenAPI v2/v3 → ToolDefinition converter
+    thulp-registry/    # async thread-safe tool registry with tags
+    thulp-browser/     # web fetching, HTML parsing, optional CDP
+    thulp-guidance/    # template rendering, LLM guidance
+    thulp-cli/         # clap CLI with JSON output + shell completions
+  examples/            # 6 runnable examples
+```
+
+### Feature flags
+
+| Crate | Flag | Description |
+|-------|------|-------------|
+| thulp-mcp | `ares` | Ares server integration |
+| thulp-browser | `cdp` | Chrome DevTools Protocol support |
+| thulp-skills | `mcp` | MCP support in skill execution |
 
 ## Development
 
-### Building
-
 ```bash
-# Build all crates
-cargo build --workspace
-
-# Build with CDP feature
-cargo build -p thulp-browser --features cdp
-
-# Build in release mode
-cargo build --workspace --release
+cargo build --workspace                     # build all
+cargo test --workspace                      # 311 tests
+cargo clippy --workspace -- -D warnings     # lint (currently clean)
+cargo bench -p thulp-core --bench tool_benchmarks  # benchmarks
 ```
 
-### Testing
+## Ecosystem
 
-```bash
-# Run all tests (183 tests)
-cargo test --workspace
-
-# Run with verbose output
-cargo test --workspace -- --nocapture
-```
-
-### Benchmarking
-
-```bash
-cargo bench -p thulp-core --bench tool_benchmarks
-```
-
-### Code Quality
-
-```bash
-cargo clippy --workspace -- -D warnings
-cargo fmt --all -- --check
-```
-
-## Project Status
-
-**Version**: 0.2.0
-
-### Complete Features
-
-- Core tool abstraction and validation
-- MCP transport (STDIO and HTTP) with tools, resources, prompts
-- Parameter type system with JSON Schema support
-- Query DSL with wildcards and boolean operators
-- Skill workflows with variable interpolation
-- SkillExecutor trait with pluggable execution strategies
-- DefaultSkillExecutor with timeout and retry support
-- ExecutionHooks for lifecycle callbacks and observability
-- Session management with turn counting and persistence
-- SessionManager for file-based session storage
-- SKILL.md file parsing with YAML frontmatter (thulp-skill-files)
-- SkillLoader with scope-based priority (Global/Workspace/Project)
-- OpenAPI v2/v3 conversion (JSON and YAML)
-- CLI with JSON output and shell completions
-- Async thread-safe tool registry with tagging
-- Browser web fetching and HTML parsing
-- 183 tests with comprehensive coverage
-
-### Feature Flags
-
-| Crate          | Flag   | Description                       |
-| -------------- | ------ | --------------------------------- |
-| thulp-mcp      | `ares` | Ares server integration           |
-| thulp-browser  | `cdp`  | Chrome DevTools Protocol support  |
-| thulp-examples | `mcp`  | MCP example                       |
-
-## Contributing
-
-Contributions are welcome! Please follow these guidelines:
-
-1. Fork the repository
-2. Create a feature branch
-3. Write tests for new functionality
-4. Ensure all tests pass: `cargo test --workspace`
-5. Run clippy: `cargo clippy --workspace -- -D warnings`
-6. Format code: `cargo fmt --all`
-7. Submit a pull request
+| Project | What |
+|---------|------|
+| [pawan](https://github.com/dirmacs/pawan) | CLI coding agent — uses thulp for tool abstraction |
+| [ares](https://github.com/dirmacs/ares) | Agentic retrieval-enhanced server |
+| [eruka](https://eruka.dirmacs.com) | Context intelligence engine |
+| [daedra](https://dirmacs.github.io/daedra) | Self-contained web search MCP server |
+| [doltares](https://github.com/dirmacs/doltares) | Orchestration daemon (DAG workflows) |
 
 ## License
 
-Licensed under either of:
-
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
-
-at your option.
+MIT OR Apache-2.0
 
 ## Links
 
-- [Repository](https://github.com/dirmacs/thulp)
-- [Crates.io](https://crates.io/search?q=thulp)
-- [Documentation](https://docs.rs/thulp-core)
+- [Documentation](https://dirmacs.github.io/thulp)
+- [API Reference](https://docs.rs/thulp-core)
+- [crates.io](https://crates.io/search?q=thulp)
 - [MCP Specification](https://modelcontextprotocol.io/)
 - [rs-utcp](https://github.com/universal-tool-calling-protocol/rs-utcp)
-
-## Acknowledgments
-
-- **rs-utcp**: UTCP protocol implementation (includes MCP transport)
-- **Anthropic**: Model Context Protocol specification
-- **UTCP**: Universal Tool Calling Protocol

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,14 +1,15 @@
 # Thulp Implementation Status
 
-**Last Updated**: February 1, 2026
+**Last Updated**: March 22, 2026
 
 ## Summary
 
-- **Total Tests**: 190+ passing
+- **Total Tests**: 311 passing
 - **Clippy**: Clean (no warnings)
 - **Build Status**: Successful
-- **Crates**: 11 crates in workspace (added thulp-skill-files)
+- **Crates**: 11 crates in workspace
 - **Latest Release**: v0.3.0 on crates.io
+- **Documentation**: [dirmacs.github.io/thulp](https://dirmacs.github.io/thulp)
 
 ## Completed Work
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,0 +1,11 @@
+base_url = "https://dirmacs.github.io/thulp"
+title = "Thulp — Execution Context Engineering for AI Agents"
+compile_sass = false
+build_search_index = false
+generate_feeds = false
+
+[markdown]
+highlight_code = true
+highlight_theme = "base16-ocean-dark"
+
+[extra]

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,3 @@
++++
+template = "index.html"
++++

--- a/docs/public/404.html
+++ b/docs/public/404.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>404 Not Found</title>
+<h1>404 Not Found</h1>

--- a/docs/public/img/thulp-logo.svg
+++ b/docs/public/img/thulp-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="20" fill="#0d1117"/>
+  <path d="M32 40h64v8H68v40h-8V48H32V40z" fill="#58a6ff"/>
+  <rect x="36" y="68" width="56" height="8" rx="2" fill="#58a6ff" opacity="0.6"/>
+  <rect x="44" y="82" width="40" height="8" rx="2" fill="#58a6ff" opacity="0.35"/>
+  <circle cx="96" cy="96" r="16" fill="none" stroke="#e94560" stroke-width="3"/>
+  <path d="M90 96l4 4 8-8" stroke="#e94560" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Thulp — Execution Context Engineering for AI Agents</title>
+    <link rel="icon" type="image/svg+xml" href="https://dirmacs.github.io/thulp/img/thulp-logo.svg">
+    <style>
+        :root { --bg: #0d1117; --fg: #c9d1d9; --accent: #58a6ff; --card: #161b22; --border: #30363d; --dim: #8b949e; --red: #e94560; }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { background: var(--bg); color: var(--fg); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; }
+        .hero { text-align: center; padding: 4rem 1rem 2rem; }
+        .hero img { width: 96px; margin-bottom: 1rem; }
+        .hero h1 { font-size: 2.5rem; color: #fff; margin-bottom: 0.5rem; }
+        .hero p { color: var(--dim); font-size: 1.1rem; max-width: 640px; margin: 0 auto 1.5rem; }
+        .badges { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 2rem; }
+        .badges img { height: 20px; }
+        .install { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; max-width: 400px; margin: 0 auto 3rem; font-family: monospace; font-size: 0.95rem; color: var(--accent); }
+        .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; max-width: 960px; margin: 0 auto; padding: 0 1rem 3rem; }
+        .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; }
+        .card h3 { color: #fff; margin-bottom: 0.5rem; }
+        .card p { color: var(--dim); font-size: 0.9rem; }
+        table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.85rem; }
+        th, td { padding: 0.5rem; text-align: left; border-bottom: 1px solid var(--border); }
+        th { color: var(--accent); }
+        .section { max-width: 960px; margin: 0 auto; padding: 0 1rem 3rem; }
+        .section h2 { color: #fff; margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+        code { background: var(--card); padding: 0.1em 0.4em; border-radius: 3px; font-size: 0.85rem; }
+        pre { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; overflow-x: auto; margin: 1rem 0; }
+        pre code { background: none; padding: 0; }
+        a { color: var(--accent); text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        footer { text-align: center; padding: 2rem; color: var(--dim); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    </style>
+</head>
+<body>
+    <div class="hero">
+        <img src="https://dirmacs.github.io/thulp/img/thulp-logo.svg" alt="Thulp">
+        <h1>Thulp</h1>
+        <p>Execution context engineering for AI agents. One interface for tool discovery, validation, execution, and multi-step workflows. Pure Rust. 11 crates.</p>
+        <div class="badges">
+            <a href="https://crates.io/crates/thulp-core"><img src="https://img.shields.io/crates/v/thulp-core.svg" alt="crates.io"></a>
+            <a href="https://github.com/dirmacs/thulp/actions/workflows/ci.yml"><img src="https://github.com/dirmacs/thulp/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+            <img src="https://img.shields.io/badge/crates-11-blue.svg" alt="11 crates">
+            <img src="https://img.shields.io/badge/tests-311-brightgreen.svg" alt="311 tests">
+            <img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-yellow.svg" alt="MIT/Apache-2.0">
+        </div>
+        <div class="install">$ cargo install thulp-cli</div>
+    </div>
+
+    <div class="grid">
+        <div class="card">
+            <h3>Unified Tool Abstraction</h3>
+            <p>One interface for local functions, MCP servers, and OpenAPI endpoints. Type-safe parameters with JSON Schema validation. Builder pattern APIs.</p>
+        </div>
+        <div class="card">
+            <h3>MCP + UTCP Protocol</h3>
+            <p>Full Model Context Protocol support via rs-utcp. STDIO and HTTP transports. Tools, resources, and prompts. Drop-in for any MCP-compatible agent.</p>
+        </div>
+        <div class="card">
+            <h3>Skill Workflows</h3>
+            <p>Compose multi-step tool chains with variable interpolation, timeout/retry policies, execution hooks, and pluggable executors. Load from SKILL.md files.</p>
+        </div>
+        <div class="card">
+            <h3>Query DSL</h3>
+            <p>Filter and search tools with a powerful query language. Wildcards, boolean operators, parameter constraints. <code>name:search and min:2</code></p>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Workspace</h2>
+        <table>
+            <tr><th>Crate</th><th>Description</th><th>Tests</th></tr>
+            <tr><td><strong>thulp-core</strong></td><td>Core types, traits, parameter validation</td><td>70</td></tr>
+            <tr><td><strong>thulp-mcp</strong></td><td>MCP transport (STDIO/HTTP), tools, resources</td><td>39</td></tr>
+            <tr><td><strong>thulp-skills</strong></td><td>Multi-step workflows, executor, hooks, retry</td><td>54</td></tr>
+            <tr><td><strong>thulp-skill-files</strong></td><td>SKILL.md parsing, YAML frontmatter, scope priority</td><td>23</td></tr>
+            <tr><td><strong>thulp-query</strong></td><td>Query DSL with nom parser</td><td>19</td></tr>
+            <tr><td><strong>thulp-workspace</strong></td><td>Sessions, persistence, turn counting</td><td>6</td></tr>
+            <tr><td><strong>thulp-adapter</strong></td><td>OpenAPI v2/v3 to tool conversion</td><td>10</td></tr>
+            <tr><td><strong>thulp-registry</strong></td><td>Async thread-safe tool registry with tagging</td><td>8</td></tr>
+            <tr><td><strong>thulp-browser</strong></td><td>Web fetching, HTML parsing, optional CDP</td><td>7</td></tr>
+            <tr><td><strong>thulp-guidance</strong></td><td>Template rendering, LLM guidance primitives</td><td>6</td></tr>
+            <tr><td><strong>thulp-cli</strong></td><td>CLI with JSON output and shell completions</td><td>36</td></tr>
+        </table>
+    </div>
+
+    <div class="section">
+        <h2>Quick Start</h2>
+        <h3>Define a Tool</h3>
+        <pre><code>use thulp_core::{ToolDefinition, Parameter, ParameterType};
+
+let tool = ToolDefinition::builder("search")
+    .description("Search for information")
+    .parameter(
+        Parameter::builder("query")
+            .param_type(ParameterType::String)
+            .required(true)
+            .build()
+    )
+    .build();</code></pre>
+
+        <h3>Connect to MCP Server</h3>
+        <pre><code>use thulp_mcp::McpClient;
+
+let client = McpClient::connect_stdio("server", "mcp-server", None).await?;
+let tools = client.list_tools().await?;
+let result = client.call(&amp;ToolCall::builder("search")
+    .arg_str("query", "rust async")
+    .build()).await?;</code></pre>
+
+        <h3>CLI</h3>
+        <pre><code>thulp tools list --output json
+thulp tools validate search --args '{"query": "rust"}'
+thulp convert openapi spec.yaml --output tools.yaml
+thulp completions bash > ~/.local/share/bash-completion/completions/thulp</code></pre>
+    </div>
+
+    <div class="section">
+        <h2>Ecosystem</h2>
+        <table>
+            <tr><th>Project</th><th>What</th></tr>
+            <tr><td><a href="https://github.com/dirmacs/pawan">pawan</a></td><td>CLI coding agent — uses thulp for tool abstraction</td></tr>
+            <tr><td><a href="https://github.com/dirmacs/ares">ares</a></td><td>Agentic retrieval-enhanced server</td></tr>
+            <tr><td><a href="https://eruka.dirmacs.com">eruka</a></td><td>Context intelligence engine</td></tr>
+            <tr><td><a href="https://dirmacs.github.io/daedra">daedra</a></td><td>Self-contained web search MCP server</td></tr>
+        </table>
+    </div>
+
+    <footer>
+        Built by <a href="https://dirmacs.com">DIRMACS</a> &middot;
+        <a href="https://github.com/dirmacs/thulp">GitHub</a> &middot;
+        <a href="https://crates.io/search?q=thulp">crates.io</a> &middot;
+        <a href="https://docs.rs/thulp-core">docs.rs</a>
+    </footer>
+</body>
+</html>

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+Allow: /
+Sitemap: https://dirmacs.github.io/thulp/sitemap.xml

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://dirmacs.github.io/thulp/</loc>
+    </url>
+</urlset>

--- a/docs/static/img/thulp-logo.svg
+++ b/docs/static/img/thulp-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="20" fill="#0d1117"/>
+  <path d="M32 40h64v8H68v40h-8V48H32V40z" fill="#58a6ff"/>
+  <rect x="36" y="68" width="56" height="8" rx="2" fill="#58a6ff" opacity="0.6"/>
+  <rect x="44" y="82" width="40" height="8" rx="2" fill="#58a6ff" opacity="0.35"/>
+  <circle cx="96" cy="96" r="16" fill="none" stroke="#e94560" stroke-width="3"/>
+  <path d="M90 96l4 4 8-8" stroke="#e94560" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config.title }}</title>
+    <link rel="icon" type="image/svg+xml" href="{{ get_url(path='img/thulp-logo.svg') }}">
+    <style>
+        :root { --bg: #0d1117; --fg: #c9d1d9; --accent: #58a6ff; --card: #161b22; --border: #30363d; --dim: #8b949e; --red: #e94560; }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { background: var(--bg); color: var(--fg); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; }
+        .hero { text-align: center; padding: 4rem 1rem 2rem; }
+        .hero img { width: 96px; margin-bottom: 1rem; }
+        .hero h1 { font-size: 2.5rem; color: #fff; margin-bottom: 0.5rem; }
+        .hero p { color: var(--dim); font-size: 1.1rem; max-width: 640px; margin: 0 auto 1.5rem; }
+        .badges { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 2rem; }
+        .badges img { height: 20px; }
+        .install { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; max-width: 400px; margin: 0 auto 3rem; font-family: monospace; font-size: 0.95rem; color: var(--accent); }
+        .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; max-width: 960px; margin: 0 auto; padding: 0 1rem 3rem; }
+        .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; }
+        .card h3 { color: #fff; margin-bottom: 0.5rem; }
+        .card p { color: var(--dim); font-size: 0.9rem; }
+        table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.85rem; }
+        th, td { padding: 0.5rem; text-align: left; border-bottom: 1px solid var(--border); }
+        th { color: var(--accent); }
+        .section { max-width: 960px; margin: 0 auto; padding: 0 1rem 3rem; }
+        .section h2 { color: #fff; margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+        code { background: var(--card); padding: 0.1em 0.4em; border-radius: 3px; font-size: 0.85rem; }
+        pre { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; overflow-x: auto; margin: 1rem 0; }
+        pre code { background: none; padding: 0; }
+        a { color: var(--accent); text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        footer { text-align: center; padding: 2rem; color: var(--dim); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    </style>
+</head>
+<body>
+    <div class="hero">
+        <img src="{{ get_url(path='img/thulp-logo.svg') }}" alt="Thulp">
+        <h1>Thulp</h1>
+        <p>Execution context engineering for AI agents. One interface for tool discovery, validation, execution, and multi-step workflows. Pure Rust. 11 crates.</p>
+        <div class="badges">
+            <a href="https://crates.io/crates/thulp-core"><img src="https://img.shields.io/crates/v/thulp-core.svg" alt="crates.io"></a>
+            <a href="https://github.com/dirmacs/thulp/actions/workflows/ci.yml"><img src="https://github.com/dirmacs/thulp/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+            <img src="https://img.shields.io/badge/crates-11-blue.svg" alt="11 crates">
+            <img src="https://img.shields.io/badge/tests-311-brightgreen.svg" alt="311 tests">
+            <img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-yellow.svg" alt="MIT/Apache-2.0">
+        </div>
+        <div class="install">$ cargo install thulp-cli</div>
+    </div>
+
+    <div class="grid">
+        <div class="card">
+            <h3>Unified Tool Abstraction</h3>
+            <p>One interface for local functions, MCP servers, and OpenAPI endpoints. Type-safe parameters with JSON Schema validation. Builder pattern APIs.</p>
+        </div>
+        <div class="card">
+            <h3>MCP + UTCP Protocol</h3>
+            <p>Full Model Context Protocol support via rs-utcp. STDIO and HTTP transports. Tools, resources, and prompts. Drop-in for any MCP-compatible agent.</p>
+        </div>
+        <div class="card">
+            <h3>Skill Workflows</h3>
+            <p>Compose multi-step tool chains with variable interpolation, timeout/retry policies, execution hooks, and pluggable executors. Load from SKILL.md files.</p>
+        </div>
+        <div class="card">
+            <h3>Query DSL</h3>
+            <p>Filter and search tools with a powerful query language. Wildcards, boolean operators, parameter constraints. <code>name:search and min:2</code></p>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Workspace</h2>
+        <table>
+            <tr><th>Crate</th><th>Description</th><th>Tests</th></tr>
+            <tr><td><strong>thulp-core</strong></td><td>Core types, traits, parameter validation</td><td>70</td></tr>
+            <tr><td><strong>thulp-mcp</strong></td><td>MCP transport (STDIO/HTTP), tools, resources</td><td>39</td></tr>
+            <tr><td><strong>thulp-skills</strong></td><td>Multi-step workflows, executor, hooks, retry</td><td>54</td></tr>
+            <tr><td><strong>thulp-skill-files</strong></td><td>SKILL.md parsing, YAML frontmatter, scope priority</td><td>23</td></tr>
+            <tr><td><strong>thulp-query</strong></td><td>Query DSL with nom parser</td><td>19</td></tr>
+            <tr><td><strong>thulp-workspace</strong></td><td>Sessions, persistence, turn counting</td><td>6</td></tr>
+            <tr><td><strong>thulp-adapter</strong></td><td>OpenAPI v2/v3 to tool conversion</td><td>10</td></tr>
+            <tr><td><strong>thulp-registry</strong></td><td>Async thread-safe tool registry with tagging</td><td>8</td></tr>
+            <tr><td><strong>thulp-browser</strong></td><td>Web fetching, HTML parsing, optional CDP</td><td>7</td></tr>
+            <tr><td><strong>thulp-guidance</strong></td><td>Template rendering, LLM guidance primitives</td><td>6</td></tr>
+            <tr><td><strong>thulp-cli</strong></td><td>CLI with JSON output and shell completions</td><td>36</td></tr>
+        </table>
+    </div>
+
+    <div class="section">
+        <h2>Quick Start</h2>
+        <h3>Define a Tool</h3>
+        <pre><code>use thulp_core::{ToolDefinition, Parameter, ParameterType};
+
+let tool = ToolDefinition::builder("search")
+    .description("Search for information")
+    .parameter(
+        Parameter::builder("query")
+            .param_type(ParameterType::String)
+            .required(true)
+            .build()
+    )
+    .build();</code></pre>
+
+        <h3>Connect to MCP Server</h3>
+        <pre><code>use thulp_mcp::McpClient;
+
+let client = McpClient::connect_stdio("server", "mcp-server", None).await?;
+let tools = client.list_tools().await?;
+let result = client.call(&amp;ToolCall::builder("search")
+    .arg_str("query", "rust async")
+    .build()).await?;</code></pre>
+
+        <h3>CLI</h3>
+        <pre><code>thulp tools list --output json
+thulp tools validate search --args '{"query": "rust"}'
+thulp convert openapi spec.yaml --output tools.yaml
+thulp completions bash > ~/.local/share/bash-completion/completions/thulp</code></pre>
+    </div>
+
+    <div class="section">
+        <h2>Ecosystem</h2>
+        <table>
+            <tr><th>Project</th><th>What</th></tr>
+            <tr><td><a href="https://github.com/dirmacs/pawan">pawan</a></td><td>CLI coding agent — uses thulp for tool abstraction</td></tr>
+            <tr><td><a href="https://github.com/dirmacs/ares">ares</a></td><td>Agentic retrieval-enhanced server</td></tr>
+            <tr><td><a href="https://eruka.dirmacs.com">eruka</a></td><td>Context intelligence engine</td></tr>
+            <tr><td><a href="https://dirmacs.github.io/daedra">daedra</a></td><td>Self-contained web search MCP server</td></tr>
+        </table>
+    </div>
+
+    <footer>
+        Built by <a href="https://dirmacs.com">DIRMACS</a> &middot;
+        <a href="https://github.com/dirmacs/thulp">GitHub</a> &middot;
+        <a href="https://crates.io/search?q=thulp">crates.io</a> &middot;
+        <a href="https://docs.rs/thulp-core">docs.rs</a>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Full README rewrite to match daedra docs quality bar
- Zola static site for dirmacs.github.io/thulp (GitHub Dark theme)
- SVG logo added
- IMPLEMENTATION_STATUS.md updated (311 tests, docs link)

### README changes
- Centered logo + badge row (crates.io, CI, docs.rs, 11 crates, 311 tests)
- Problem-solution framing ("Why Thulp?")
- Single workspace table with per-crate test counts
- Quick start: tool definition, MCP, skills, query DSL
- Architecture tree, feature flags table
- Ecosystem links (pawan, ares, eruka, daedra, doltares)

### Zola site
- Hero section with badges and `cargo install thulp-cli`
- 4-card feature grid (Unified Tool Abstraction, MCP+UTCP, Skill Workflows, Query DSL)
- Workspace table with all 11 crates and test counts
- Quick start code samples
- Ecosystem table and footer links

## Test plan
- [x] `cargo test --workspace` — 311 tests pass
- [x] `cargo clippy --workspace` — clean
- [x] `zola build` in docs/ — builds successfully
- [ ] Enable GitHub Pages on master after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)