### PR TITLE
fix: remove private repo link from README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# thulp — Agent Guidelines
+
+## What This Is
+
+Thulp handles tool discovery, validation, and execution for AI agents. It provides a unified abstraction over local Rust functions, MCP servers, and OpenAPI endpoints. Skills chain tools into reusable workflows.
+
+## For Agents
+
+- Run `cargo test --workspace` — 211 tests must pass
+- thulp-core is the foundation — changes there affect everything
+- Query DSL uses nom parser — test with `cargo test -p thulp-query`
+- SKILL.md parsing is in thulp-skill-files — validate against real skill files
+- MCP transport is in thulp-mcp — test with mock servers, not live ones
+- Don't add deps between core and other crates — core stays independent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# thulp
+
+Execution context engineering for AI agents. Tool discovery, validation, execution, multi-step skill workflows. 11-crate Rust workspace.
+
+## Build & Test
+
+```bash
+cargo build --workspace
+cargo test --workspace          # 211 tests
+cargo clippy --workspace -- -D warnings
+```
+
+## Architecture
+
+- `thulp-core` (70 tests) — types, traits, validation, JSON Schema
+- `thulp-mcp` (39 tests) — MCP transport client
+- `thulp-skills` (54 tests) — workflow engine, skill execution
+- `thulp-skill-files` (23 tests) — SKILL.md parsing
+- `thulp-query` (19 tests) — DSL parser (nom-based)
+- `thulp-cli` (32 tests) — clap CLI
+- `thulp-openapi`, `thulp-cdp`, `thulp-session`, `thulp-ares`, `thulp-registry`
+
+## Conventions
+
+- Git author: `bkataru <baalateja.k@gmail.com>`
+- thulp-core is independent — zero deps on other thulp crates
+- Feature flags: `ares`, `cdp`, `mcp` for optional integrations
+- nom parser for query DSL
+- async-trait for trait objects

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-examples"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde_json",
  "thulp-adapter",
@@ -7100,7 +7100,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-skill-files"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs 5.0.1",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "ares-server"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a433d0e3cf6b873df29e02b59a7d623775dbc427f983f812053a40576f9980"
+checksum = "9ac6c7dde26775d1e3cf73d513d490d748f823fffde5b21e8f25a3034fd62239"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -246,11 +246,12 @@ dependencies = [
  "clap",
  "config",
  "daedra",
- "dotenv",
+ "dotenvy",
  "fastembed",
  "futures",
  "jsonwebtoken",
  "libsql",
+ "lru 0.16.3",
  "notify",
  "owo-colors",
  "parking_lot",
@@ -270,6 +271,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-sessions",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "utoipa",
@@ -507,6 +509,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
 ]
 
 [[package]]
@@ -906,12 +931,6 @@ dependencies = [
  "ctr",
  "subtle",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1547,7 +1566,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1567,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "daedra"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dbb0e47d3a8ec721f0bfb757f6cf092264113fc3e4396a6b27b880e8fd11cf"
+checksum = "538707e41a2fa739e643f67de8373d82d6e96ef394863b08f482b5b69aeec8a3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1580,7 +1598,7 @@ dependencies = [
  "colored",
  "futures",
  "governor",
- "html2md",
+ "htmd",
  "html5ever 0.36.1",
  "lazy_static",
  "moka",
@@ -1897,10 +1915,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtls"
@@ -1954,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,30 +1995,6 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2346,6 +2346,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2826,31 +2842,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "html2md"
-version = "0.2.15"
+name = "htmd"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cff9891f2e0d9048927fbdfc28b11bf378f6a93c7ba70b23d0fbee9af6071b4"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
 dependencies = [
- "html5ever 0.27.0",
- "jni",
- "lazy_static",
+ "html5ever 0.38.0",
  "markup5ever_rcdom",
- "percent-encoding",
- "regex",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.12.1",
- "proc-macro2",
- "quote",
- "syn",
+ "phf 0.13.1",
 ]
 
 [[package]]
@@ -2872,6 +2871,16 @@ checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
 dependencies = [
  "log",
  "markup5ever 0.36.1",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -3048,6 +3057,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3521,26 +3543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
-dependencies = [
- "cesu8",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3573,23 +3575,17 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.2.0"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.5",
- "rsa",
  "serde",
  "serde_json",
- "sha2",
  "signature",
  "simple_asn1",
 ]
@@ -3619,9 +3615,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -3708,7 +3701,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.11.0",
  "tonic-web",
  "tower 0.4.13",
  "tower-http 0.4.4",
@@ -3807,7 +3800,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.11.0",
  "tracing",
  "uuid",
  "zerocopy 0.7.35",
@@ -3878,6 +3871,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3922,26 +3924,12 @@ checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
- "tendril",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.4.3",
  "web_atoms 0.1.3",
 ]
 
@@ -3952,19 +3940,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.4.3",
+ "web_atoms 0.2.1",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
  "web_atoms 0.2.1",
 ]
 
 [[package]]
 name = "markup5ever_rcdom"
-version = "0.3.0"
+version = "0.38.0+unofficial"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
 dependencies = [
- "html5ever 0.27.0",
- "markup5ever 0.12.1",
- "tendril",
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
+ "tendril 0.5.0",
  "xml5ever",
 ]
 
@@ -4252,6 +4251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,22 +4312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4358,17 +4347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,7 +4364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -4949,17 +4926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5421,7 +5387,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -5796,7 +5762,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5839,29 +5805,9 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
- "tonic",
+ "tonic 0.11.0",
  "tonic-build",
  "webrtc",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -6034,7 +5980,7 @@ checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6045,7 +5991,7 @@ checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6153,7 +6099,7 @@ dependencies = [
  "html5ever 0.35.0",
  "precomputed-hash",
  "selectors 0.31.0",
- "tendril",
+ "tendril 0.4.3",
 ]
 
 [[package]]
@@ -6168,7 +6114,7 @@ dependencies = [
  "html5ever 0.36.1",
  "precomputed-hash",
  "selectors 0.33.0",
- "tendril",
+ "tendril 0.4.3",
 ]
 
 [[package]]
@@ -6651,6 +6597,7 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
+ "serde",
 ]
 
 [[package]]
@@ -6884,6 +6831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "tera"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6983,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-adapter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "regex",
  "reqwest 0.12.28",
@@ -6995,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-browser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.12.28",
@@ -7009,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -7025,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -7052,7 +7009,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-guidance"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7062,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ares-server",
  "async-trait",
@@ -7077,7 +7034,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-query"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "nom 7.1.3",
  "regex",
@@ -7089,7 +7046,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-registry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -7115,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-skills"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "fastrand",
@@ -7133,7 +7090,7 @@ dependencies = [
 
 [[package]]
 name = "thulp-workspace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7458,7 +7415,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost",
@@ -7468,6 +7425,35 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tokio-stream",
  "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum 0.8.8",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7499,7 +7485,7 @@ dependencies = [
  "hyper 0.14.32",
  "pin-project",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
  "tower-http 0.4.4",
  "tower-layer",
  "tower-service",
@@ -7690,6 +7676,23 @@ dependencies = [
  "time",
  "tokio",
  "tower-sessions-core",
+]
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum 0.8.8",
+ "forwarded-header-value",
+ "governor",
+ "http 1.4.0",
+ "pin-project",
+ "thiserror 2.0.17",
+ "tonic 0.14.5",
+ "tower 0.5.3",
+ "tracing",
 ]
 
 [[package]]
@@ -7940,6 +7943,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -8907,13 +8916,12 @@ dependencies = [
 
 [[package]]
 name = "xml5ever"
-version = "0.18.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
 dependencies = [
  "log",
- "mac",
- "markup5ever 0.12.1",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Built by [DIRMACS](https://dirmacs.com).
 ## Install
 
 ```bash
-cargo install thulp-cli
+cargo install thulp
 ```
 
 ```toml
@@ -62,7 +62,7 @@ No runtime overhead. No framework lock-in. Pure Rust async.
 | **thulp-registry** | Async thread-safe tool registry with tagging | 8 |
 | **thulp-browser** | Web fetching, HTML parsing, optional CDP | 7 |
 | **thulp-guidance** | Template rendering, LLM guidance primitives | 6 |
-| **thulp-cli** | CLI with JSON output, shell completions, init/run/skill/config commands | 32 |
+| **thulp** | CLI with JSON output, shell completions, init/run/skill/config commands | 32 |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ cargo bench -p thulp-core --bench tool_benchmarks  # benchmarks
 | [ares](https://github.com/dirmacs/ares) | Agentic retrieval-enhanced server |
 | [eruka](https://eruka.dirmacs.com) | Context intelligence engine |
 | [daedra](https://dirmacs.github.io/daedra) | Self-contained web search MCP server |
-| [doltares](https://github.com/dirmacs/doltares) | Orchestration daemon (DAG workflows) |
 
 ## License
 

--- a/crates/thulp-adapter/Cargo.toml
+++ b/crates/thulp-adapter/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "Adapter for converting external tool definitions to thulp format"
+readme = "README.md"
 rust-version = "1.75"
 
 [lib]

--- a/crates/thulp-adapter/Cargo.toml
+++ b/crates/thulp-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-adapter"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ name = "thulp_adapter"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/thulp-browser/Cargo.toml
+++ b/crates/thulp-browser/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "Browser automation tools for thulp"
+readme = "README.md"
 rust-version = "1.75"
 
 edition = "2021"

--- a/crates/thulp-browser/Cargo.toml
+++ b/crates/thulp-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-browser"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -15,7 +15,7 @@ name = "thulp_browser"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/thulp-cli/Cargo.toml
+++ b/crates/thulp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "thulp-cli"
-version = "0.3.1"
+name = "thulp"
+version = "0.3.2"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"

--- a/crates/thulp-cli/Cargo.toml
+++ b/crates/thulp-cli/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "CLI for thulp - Execution context engineering platform"
+readme = "README.md"
 rust-version = "1.75"
 
 [[bin]]

--- a/crates/thulp-cli/Cargo.toml
+++ b/crates/thulp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
@@ -14,9 +14,9 @@ name = "thulp"
 path = "src/main.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
-thulp-mcp = { path = "../thulp-mcp", version = "0.3.0", optional = true }
-thulp-adapter = { path = "../thulp-adapter", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
+thulp-mcp = { path = "../thulp-mcp", version = "0.3.1", optional = true }
+thulp-adapter = { path = "../thulp-adapter", version = "0.3.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/thulp-core/Cargo.toml
+++ b/crates/thulp-core/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "Core types and traits for thulp"
+readme = "README.md"
 rust-version = "1.75"
 
 [dependencies]

--- a/crates/thulp-core/Cargo.toml
+++ b/crates/thulp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"

--- a/crates/thulp-guidance/Cargo.toml
+++ b/crates/thulp-guidance/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "LLM guidance and orchestration for thulp"
+readme = "README.md"
 rust-version = "1.75"
 
 edition = "2021"

--- a/crates/thulp-guidance/Cargo.toml
+++ b/crates/thulp-guidance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-guidance"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -15,7 +15,7 @@ name = "thulp_guidance"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 serde_json = "1.0"

--- a/crates/thulp-mcp/Cargo.toml
+++ b/crates/thulp-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-mcp"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -15,7 +15,7 @@ name = "thulp_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -28,7 +28,7 @@ rs-utcp = { version = "0.3" }
 
 # ares-server - optional integration for production-grade MCP support
 # Patched via root [patch.crates-io] to avoid workspace conflict
-ares-server = { version = "0.3.0", default-features = false, features = ["ares-vector"], optional = true }
+ares-server = { version = "0.3.1", default-features = false, features = ["ares-vector"], optional = true }
 
 [features]
 default = []

--- a/crates/thulp-mcp/Cargo.toml
+++ b/crates/thulp-mcp/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "MCP (Model Context Protocol) integration for thulp"
+readme = "README.md"
 rust-version = "1.75"
 
 edition = "2021"

--- a/crates/thulp-query/Cargo.toml
+++ b/crates/thulp-query/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "Query engine for searching and filtering thulp tools"
+readme = "README.md"
 rust-version = "1.75"
 
 edition = "2021"

--- a/crates/thulp-query/Cargo.toml
+++ b/crates/thulp-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-query"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -15,7 +15,7 @@ name = "thulp_query"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 nom = "7.1"

--- a/crates/thulp-registry/Cargo.toml
+++ b/crates/thulp-registry/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "Tool registry and management for thulp"
+readme = "README.md"
 rust-version = "1.75"
 
 edition = "2021"

--- a/crates/thulp-registry/Cargo.toml
+++ b/crates/thulp-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-registry"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -15,7 +15,7 @@ name = "thulp_registry"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/thulp-skill-files/Cargo.toml
+++ b/crates/thulp-skill-files/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "SKILL.md file parsing and loading for Thulp"
+readme = "README.md"
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/thulp-skills/Cargo.toml
+++ b/crates/thulp-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-skills"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -15,9 +15,9 @@ name = "thulp_skills"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
-thulp-mcp = { path = "../thulp-mcp", version = "0.3.0", optional = true }
-thulp-query = { path = "../thulp-query", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
+thulp-mcp = { path = "../thulp-mcp", version = "0.3.1", optional = true }
+thulp-query = { path = "../thulp-query", version = "0.3.1" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/thulp-skills/Cargo.toml
+++ b/crates/thulp-skills/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "Skill composition and execution for thulp"
+readme = "README.md"
 rust-version = "1.75"
 
 edition = "2021"

--- a/crates/thulp-workspace/Cargo.toml
+++ b/crates/thulp-workspace/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
 description = "Workspace management for thulp execution contexts"
+readme = "README.md"
 rust-version = "1.75"
 
 edition = "2021"

--- a/crates/thulp-workspace/Cargo.toml
+++ b/crates/thulp-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thulp-workspace"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dirmacs <contact@dirmacs.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dirmacs/thulp"
@@ -15,7 +15,7 @@ name = "thulp_workspace"
 path = "src/lib.rs"
 
 [dependencies]
-thulp-core = { path = "../thulp-core", version = "0.3.0" }
+thulp-core = { path = "../thulp-core", version = "0.3.1" }
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"


### PR DESCRIPTION
## Summary
- Remove 404-causing link to private doltares repo from the public README project table

## Test plan
- [x] Verify README renders correctly without the removed row

🤖 Generated with [Claude Code](https://claude.com/claude-code)