### PR TITLE
docs: humanize README — remove negative framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Every AI agent needs tools. But each agent framework invents its own tool format
 - **Query DSL** finds tools by name, parameter count, or tags — `name:search and min:2`
 - **Session persistence** tracks turns, enforces limits, stores results to disk
 
-No runtime overhead. No framework lock-in. Pure Rust async.
+Pure Rust async. Zero overhead. Bring your own stack.
 
 ## Workspace (11 crates)
 


### PR DESCRIPTION
Remove "No runtime overhead. No framework lock-in." (negative framing pattern) and replace with positive equivalent: "Pure Rust async. Zero overhead. Bring your own stack."

Part of dirmacs humanizer sweep across public OSS READMEs.